### PR TITLE
 Fix off-by-one error in WooCommerce subsite creation

### DIFF
--- a/deployment/woocommerce/scripts/setup.sh
+++ b/deployment/woocommerce/scripts/setup.sh
@@ -369,7 +369,7 @@ load_users_from_json() {
     # Extract users data from JSON file, starting from specified index
     # Note: jq array indexing is 0-based, so we subtract 1 from start_index
     local jq_start=$((start_index - 1))
-    local jq_end=$((jq_start + count - 1))
+    local jq_end=$((jq_start + count))
     
     jq -r ".users[${jq_start}:${jq_end}] | .[] | \"\(.id)|\(.first_name)|\(.last_name)|\(.full_name)|\(.email)|\(.password)|\(.woocommerce_consumer_key)|\(.woocommerce_consumer_secret)\"" "$users_file"
 }


### PR DESCRIPTION
# Fix off-by-one error in WooCommerce subsite creation

## Changes
Fixed `load_users_from_json()` to create the correct number of subsites.

**File**: `deployment/woocommerce/scripts/setup.sh`  

## Problem
Requesting 20 subsites only created 19. jq's slice `[start:end]` is half-open, so the end index should be `start + count`, not `start + count - 1`.

## Diff
```diff
- local jq_end=$((jq_start + count - 1))
+ local jq_end=$((jq_start + count))
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix subsites count calculation**
> 
> - Adjusts `load_users_from_json()` in `deployment/woocommerce/scripts/setup.sh` to use `jq_end=$((jq_start + count))`, aligning with jq’s half-open slice and ensuring the requested number of users generates the same number of subsites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ee6edb8079c326f6481e11167710233cf0bc6a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->