### PR TITLE
Fix Fix CVE-2025-68143, CVE-2025-68145 & CVE-2025-68144

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "mcp-ocr>=0.1.2",
     "mcp-scholarly==0.1.0",
     "mcp-server-fetch>=2025.4.7",
-    "mcp-server-git==2025.1.14",
+    "mcp-server-git==2026.1.14",
     "mcp-server-time==0.6.2",
     "mcp-yahoo-finance>=0.1.3",
     "mpmath==1.3.0",


### PR DESCRIPTION
https://cyata.ai/blog/cyata-research-breaking-anthropics-official-mcp-server/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency pin to the latest `mcp-server-git` release.
> 
> - Changes `pyproject.toml` to use `mcp-server-git==2026.1.14` (from `2025.1.14`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a2e020b8719e7832324f4e1e27bdf9fb3ad29d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->