### PR TITLE
[fix] fix bug ModuleNotFoundError: No module named 'utils'

### DIFF
--- a/tasks/finalpool/meeting-assign/evaluation/main.py
+++ b/tasks/finalpool/meeting-assign/evaluation/main.py
@@ -9,6 +9,13 @@ import json
 import re
 from datetime import datetime, timedelta, timezone
 import os
+
+# Add project root directory to sys.path for utils imports
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.abspath(os.path.join(current_dir, "../../../.."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
 from utils.general.helper import normalize_str
 
 def check_local_email(target_email="jjones@mcp.com", agent_email="donna_castillo56@mcp.com"):


### PR DESCRIPTION
Title: Fix `ModuleNotFoundError: No module named 'utils'` when evaluate for task "meeting-assign".

## Summary
This PR fixes an import error in `tasks/finalpool/meeting-assign/evaluation/main.py` (`ModuleNotFoundError: No module named 'utils'`) that occurs when evaluation. The root cause is that the project root is not on `sys.path` in that execution mode, so top-level imports like `from utils.general.helper import normalize_str` fail.

## What changed
- Add a small bootstrap snippet in `tasks/finalpool/meeting-assign/evaluation/main.py` to ensure the project root directory is added to `sys.path` before importing `utils`.
- Keep the rest of the logic unchanged.

## Reproduction
Before this PR:
```bash
python eval_client.py run \
  --mode public \
  --base-url https://xxx \
  --model-name deepseek-v3.2 \
  --output-dir ./results/deepseek-v3.2 \
  --server-host 0.0.0.0 \
  --api-key sk-xxx\
  --workers 10 \
  --server-port 8080 \
  --task-list-file ./debug_tasks.txt
# 🌐 Running remote checks...
❌ Remote check failed
Traceback (most recent call last):
  File "/workspace/tasks/finalpool/meeting-assign/evaluation/check_remote.py", line 8, in <module>
    from utils.general.helper import normalize_str
ModuleNotFoundError: No module named 'utils'
```

After this PR:
```bash
python eval_client.py run \
  --mode public \
  --base-url https://xxx \
  --model-name deepseek-v3.2 \
  --output-dir ./results/deepseek-v3.2 \
  --server-host 0.0.0.0 \
  --api-key sk-xxx\
  --workers 10 \
  --server-port 8080 \
  --task-list-file ./debug_tasks.txt
# runs without the import error
```

Fixes: import failure in `tasks/finalpool/meeting-assign/evaluation/main.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Python import path bootstrapping in an evaluation script; no business logic or data flow changes beyond fixing the `utils` import resolution.
> 
> **Overview**
> Fixes `ModuleNotFoundError: No module named 'utils'` during `meeting-assign` evaluation by prepending the repository root to `sys.path` in `evaluation/main.py` before importing `utils`.
> 
> No functional changes to the email verification logic; evaluation failures still raise `RuntimeError` with the underlying message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2598347652dfb63417d3b54371fce70b3ab5683c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->