### PR TITLE
notion: fix OAuth refresh-token rotation across task containers

### DIFF
--- a/scripts/run_single_containerized.sh
+++ b/scripts/run_single_containerized.sh
@@ -250,6 +250,19 @@ output_folder=$(realpath "$output_folder")
 RUN_LOG_DIR=$(realpath "$RUN_LOG_DIR")
 
 # Add mounts
+# Bind-mount the host's configs/.mcp-auth so OAuth-refresh writes from
+# mcp-remote inside the container persist back to host disk.  Notion's
+# OAuth refresh_token rotates on every use; without this, the rotated
+# token would die with the container and the next container would
+# read a stale (now-invalidated) token and fail with "Grant not found".
+# The mount path matches MCP_REMOTE_CONFIG_DIR in
+# configs/mcp_servers/notion_official.yaml ("./configs/.mcp-auth", which
+# resolves to /workspace/configs/.mcp-auth inside the container).
+mkdir -p "$PROJECT_ROOT/configs/.mcp-auth"
+START_CONTAINER_ARGS+=(
+    "-v" "$PROJECT_ROOT/configs/.mcp-auth:/workspace/configs/.mcp-auth"
+)
+
 START_CONTAINER_ARGS+=(
     # Mount output folder as /workspace/dumps
     "-v" "$output_folder:/workspace/dumps"
@@ -324,17 +337,29 @@ $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/deployment/canvas
 $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/global_preparation"
 $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/tasks"
 
-# Copy basic files and directories to container
+# Copy basic files and directories to container.
+#
+# For directories, use the ``src/.`` ("contents only") cp pattern with the
+# destination pre-created.  Plain ``docker cp src dest`` would put src
+# INSIDE dest when dest exists — and dest does exist whenever a bind
+# mount above caused Docker to auto-create the destination's parent
+# (e.g. /workspace/configs is auto-created here because we bind-mount
+# /workspace/configs/.mcp-auth).  Without this pattern, configs/ contents
+# would land at /workspace/configs/configs/* instead of /workspace/configs/*,
+# breaking module imports like ``configs.global_configs``.
 for item in "${FILES_TO_COPY[@]}"; do
     if [ -e "$PROJECT_ROOT/$item" ]; then
         echo "  Copying $item to container..."
         if [ -d "$PROJECT_ROOT/$item" ]; then
+            $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/$item"
+            $CONTAINER_RUNTIME cp "$PROJECT_ROOT/$item/." "$CONTAINER_NAME:/workspace/$item/"
+        else
             parent_dir=$(dirname "$item")
             if [ "$parent_dir" != "." ]; then
                 $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/$parent_dir"
             fi
+            $CONTAINER_RUNTIME cp "$PROJECT_ROOT/$item" "$CONTAINER_NAME:/workspace/$item"
         fi
-        $CONTAINER_RUNTIME cp "$PROJECT_ROOT/$item" "$CONTAINER_NAME:/workspace/$item"
     fi
 done
 

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -366,6 +366,19 @@ preprocess_log_path="${output_folder}/preprocess.log"
 gateway_log_path="${output_folder}/gateway.log"
 eval_log_path="${output_folder}/eval.log"
 
+# Bind-mount the host's configs/.mcp-auth so OAuth-refresh writes from
+# mcp-remote inside the container persist back to host disk.  Notion's
+# OAuth refresh_token rotates on every use; without this, the rotated
+# token would die with the container and the next container would
+# read a stale (now-invalidated) token and fail with "Grant not found".
+# The mount path matches MCP_REMOTE_CONFIG_DIR in
+# configs/mcp_servers/notion_official.yaml ("./configs/.mcp-auth", which
+# resolves to /workspace/configs/.mcp-auth inside the container).
+mkdir -p "$PROJECT_ROOT/configs/.mcp-auth"
+START_CONTAINER_ARGS+=(
+    "-v" "$PROJECT_ROOT/configs/.mcp-auth:/workspace/configs/.mcp-auth"
+)
+
 # Add mounts
 START_CONTAINER_ARGS+=(
     # Mount output folder as /workspace/dumps
@@ -441,17 +454,29 @@ $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/deployment/canvas
 $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/global_preparation"
 $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/tasks"
 
-# Copy basic files and directories to container
+# Copy basic files and directories to container.
+#
+# For directories, use the ``src/.`` ("contents only") cp pattern with the
+# destination pre-created.  Plain ``docker cp src dest`` would put src
+# INSIDE dest when dest exists — and dest does exist whenever a bind
+# mount above caused Docker to auto-create the destination's parent
+# (e.g. /workspace/configs is auto-created here because we bind-mount
+# /workspace/configs/.mcp-auth).  Without this pattern, configs/ contents
+# would land at /workspace/configs/configs/* instead of /workspace/configs/*,
+# breaking module imports like ``configs.global_configs``.
 for item in "${FILES_TO_COPY[@]}"; do
     if [ -e "$PROJECT_ROOT/$item" ]; then
         echo "  Copying $item to container..."
         if [ -d "$PROJECT_ROOT/$item" ]; then
+            $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/$item"
+            $CONTAINER_RUNTIME cp "$PROJECT_ROOT/$item/." "$CONTAINER_NAME:/workspace/$item/"
+        else
             parent_dir=$(dirname "$item")
             if [ "$parent_dir" != "." ]; then
                 $CONTAINER_RUNTIME exec "$CONTAINER_NAME" mkdir -p "/workspace/$parent_dir"
             fi
+            $CONTAINER_RUNTIME cp "$PROJECT_ROOT/$item" "$CONTAINER_NAME:/workspace/$item"
         fi
-        $CONTAINER_RUNTIME cp "$PROJECT_ROOT/$item" "$CONTAINER_NAME:/workspace/$item"
     fi
 done
 

--- a/utils/app_specific/notion/notion_page_duplicator.py
+++ b/utils/app_specific/notion/notion_page_duplicator.py
@@ -31,8 +31,70 @@ from playwright.sync_api import Browser, Page, sync_playwright, TimeoutError as 
 
 from utils.mcp.tool_servers import MCPServerManager, call_tool_with_retry, ToolCallError
 import asyncio
+import fcntl
 import json
 import time
+
+# Filesystem lock around the notion_official MCP server context.
+#
+# Notion's OAuth uses refresh-token rotation: each refresh issues a NEW
+# refresh_token and invalidates the previous one.  mcp-remote (the npm
+# client we use for notion_official) persists rotated tokens back to its
+# config dir on disk; if two task containers run this duplicator in
+# parallel, their mcp-remote subprocesses can both attempt to refresh the
+# same on-disk refresh_token, race the rotation, and leave the on-disk
+# state dead ("Grant not found" on subsequent refresh).
+#
+# We serialise the refresh-vulnerable window — from MCPServerManager
+# instantiation through the end of the ``async with`` block — with an
+# advisory ``flock`` on a sibling file in the same .mcp-auth directory.
+# The lock is held only briefly (typically tens of seconds, the duration
+# of the duplicate + move + page-ready wait); other concurrent task
+# preprocesses block here and proceed serially.  Filesystem flock
+# (instead of an in-process asyncio.Lock) so the serialisation works
+# across separate containers sharing the same bind-mounted .mcp-auth.
+#
+# Path is relative to the working dir (``/workspace`` inside task
+# containers, matching MCP_REMOTE_CONFIG_DIR in notion_official.yaml).
+_NOTION_OFFICIAL_LOCK_PATH = "./configs/.mcp-auth/notion_official_refresh.lock"
+_NOTION_OFFICIAL_LOCK_WAIT_SECONDS = 600  # 10 min cap; well under v3's 30-min setup reaper
+
+
+async def _acquire_notion_official_lock(timeout_seconds: float = _NOTION_OFFICIAL_LOCK_WAIT_SECONDS):
+    """Acquire an exclusive advisory ``flock`` on the notion_official lock
+    file, polling non-blockingly every 0.5 s up to ``timeout_seconds``.
+
+    Returns the open file handle (caller must release via fcntl.LOCK_UN
+    and close it in a finally block).  Raises ``RuntimeError`` if the
+    lock can't be acquired within the timeout.
+    """
+    import os as _os
+    lock_path = _NOTION_OFFICIAL_LOCK_PATH
+    # ensure containing dir exists (e.g. if .mcp-auth was just bind-mounted from empty)
+    _os.makedirs(_os.path.dirname(lock_path), exist_ok=True)
+    fd = open(lock_path, "a+")
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except BlockingIOError:
+            if time.monotonic() > deadline:
+                fd.close()
+                raise RuntimeError(
+                    f"notion_official refresh lock contended for "
+                    f">{timeout_seconds:.0f}s at {lock_path}; giving up"
+                )
+            await asyncio.sleep(0.5)
+
+
+def _release_notion_official_lock(fd):
+    """Release + close an flock acquired by _acquire_notion_official_lock."""
+    try:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+    except Exception:
+        pass
+    fd.close()
 
 # Import the protection module
 import sys
@@ -466,99 +528,109 @@ class NotionPageDuplicator:
     
     async def duplicate_page_with_mcp(self, child_page_id: str, target_parent_id: str, child_name: str) -> Optional[str]:
         # the functionlity is the same as with playwright but we use notion official mcp to do so
-        notion_official_server = MCPServerManager(agent_workspace="./").servers['notion_official']
-        async with notion_official_server as server:
-            res = await call_tool_with_retry(server, "notion-duplicate-page", {"page_id": child_page_id})
-            data = json.loads(res.content[0].text)
+        #
+        # The flock around the MCP server context serialises concurrent
+        # callers across processes/containers, so mcp-remote's rotated
+        # refresh_tokens (written to the bind-mounted .mcp-auth dir) can't
+        # be raced by a sibling task.  The lock is held from before the
+        # mcp-remote subprocess starts until after it has torn down.
+        lock_fd = await _acquire_notion_official_lock()
+        try:
+            notion_official_server = MCPServerManager(agent_workspace="./").servers['notion_official']
+            async with notion_official_server as server:
+                res = await call_tool_with_retry(server, "notion-duplicate-page", {"page_id": child_page_id})
+                data = json.loads(res.content[0].text)
 
-            # Check if duplication was successful
-            if 'name' in data and data.get('name') == 'APIResponseError':
-                error_body = json.loads(data.get('body', '{}'))
-                error_msg = error_body.get('message', 'Unknown error')
-                raise Exception(f"Failed to duplicate page: {error_msg}")
+                # Check if duplication was successful
+                if 'name' in data and data.get('name') == 'APIResponseError':
+                    error_body = json.loads(data.get('body', '{}'))
+                    error_msg = error_body.get('message', 'Unknown error')
+                    raise Exception(f"Failed to duplicate page: {error_msg}")
 
-            duplicated_page_id = data['page_id']
-            print(f"Duplicated page ID: {duplicated_page_id}")
-            self.duplicated_page_id = duplicated_page_id
-            print(f"Target parent ID: {target_parent_id}")
-            # use notion api to check if the page is ready, if not we wait for 1s
+                duplicated_page_id = data['page_id']
+                print(f"Duplicated page ID: {duplicated_page_id}")
+                self.duplicated_page_id = duplicated_page_id
+                print(f"Target parent ID: {target_parent_id}")
+                # use notion api to check if the page is ready, if not we wait for 1s
 
-            timeout = 600
-            current_time = 0
-            page_ready = False
-            page_type = None
-            while current_time < timeout:
-                try:
-                    page_info = self.notion_client.pages.retrieve(page_id=duplicated_page_id)
-                    if page_info:
-                        page_ready = True
-                        page_type = page_info.get('object', 'unknown')
-                        print(f"Page is ready! Object type: {page_type}")
-                        break
-                except Exception as e:
-                    print(f"Page not ready! Waiting for 1s... Error: {e}")
-                    time.sleep(1)
-                    current_time += 1
-            if not page_ready:
-                raise Exception(f"Page not ready after {timeout} seconds!")
+                timeout = 600
+                current_time = 0
+                page_ready = False
+                page_type = None
+                while current_time < timeout:
+                    try:
+                        page_info = self.notion_client.pages.retrieve(page_id=duplicated_page_id)
+                        if page_info:
+                            page_ready = True
+                            page_type = page_info.get('object', 'unknown')
+                            print(f"Page is ready! Object type: {page_type}")
+                            break
+                    except Exception as e:
+                        print(f"Page not ready! Waiting for 1s... Error: {e}")
+                        time.sleep(1)
+                        current_time += 1
+                if not page_ready:
+                    raise Exception(f"Page not ready after {timeout} seconds!")
 
-            # Additional check for page type
-            if page_type != 'page':
-                print(f"WARNING: Retrieved object type is '{page_type}', not 'page'. This might cause issues.")
+                # Additional check for page type
+                if page_type != 'page':
+                    print(f"WARNING: Retrieved object type is '{page_type}', not 'page'. This might cause issues.")
 
-            # Try to move the page with retry logic for "not ready" errors
-            max_move_attempts = 8
-            move_attempt = 0
-            move_successful = False
+                # Try to move the page with retry logic for "not ready" errors
+                max_move_attempts = 8
+                move_attempt = 0
+                move_successful = False
 
-            while move_attempt < max_move_attempts:
-                move_attempt += 1
+                while move_attempt < max_move_attempts:
+                    move_attempt += 1
 
-                try:
-                    res = await call_tool_with_retry(server, "notion-move-pages", {
-                            "page_or_database_ids": [duplicated_page_id],
-                            "new_parent": {
-                                "page_id":target_parent_id
+                    try:
+                        res = await call_tool_with_retry(server, "notion-move-pages", {
+                                "page_or_database_ids": [duplicated_page_id],
+                                "new_parent": {
+                                    "page_id":target_parent_id
+                                    }
                                 }
-                            }
-                        )
-                    data = json.loads(res.content[0].text)
-                    print(data)
+                            )
+                        data = json.loads(res.content[0].text)
+                        print(data)
 
-                    # Check if it's an error response
-                    if 'name' in data and data.get('name') == 'APIResponseError':
-                        error_body = json.loads(data.get('body', '{}'))
-                        error_msg = error_body.get('message', 'Unknown error')
-                        error_code = error_body.get('code', '')
+                        # Check if it's an error response
+                        if 'name' in data and data.get('name') == 'APIResponseError':
+                            error_body = json.loads(data.get('body', '{}'))
+                            error_msg = error_body.get('message', 'Unknown error')
+                            error_code = error_body.get('code', '')
 
-                        # Check if it's a "not ready" error
-                        if 'not a page or database' in error_msg.lower() or error_code == 'validation_error':
-                            if move_attempt < max_move_attempts:
-                                wait_time = 2 ** move_attempt # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s, 1024s
-                                print(f"Page not fully ready yet (attempt {move_attempt}/{max_move_attempts}). Waiting {wait_time}s before retry...")
-                                time.sleep(wait_time)
-                                continue
+                            # Check if it's a "not ready" error
+                            if 'not a page or database' in error_msg.lower() or error_code == 'validation_error':
+                                if move_attempt < max_move_attempts:
+                                    wait_time = 2 ** move_attempt # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s, 1024s
+                                    print(f"Page not fully ready yet (attempt {move_attempt}/{max_move_attempts}). Waiting {wait_time}s before retry...")
+                                    time.sleep(wait_time)
+                                    continue
 
-                        raise Exception(f"Failed to move the page: {error_msg}")
+                            raise Exception(f"Failed to move the page: {error_msg}")
 
-                    if 'result' not in data or not data['result'].startswith("Success"):
-                        raise Exception(f"Failed to move the page: {data.get('result', 'No result returned')}")
+                        if 'result' not in data or not data['result'].startswith("Success"):
+                            raise Exception(f"Failed to move the page: {data.get('result', 'No result returned')}")
 
-                    # Success!
-                    move_successful = True
-                    break
+                        # Success!
+                        move_successful = True
+                        break
 
-                except Exception as e:
-                    if move_attempt >= max_move_attempts:
-                        raise
-                    # For other exceptions, also retry
-                    wait_time = move_attempt * 2
-                    print(f"Move failed (attempt {move_attempt}/{max_move_attempts}): {e}")
-                    print(f"Waiting {wait_time}s before retry...")
-                    time.sleep(wait_time)
+                    except Exception as e:
+                        if move_attempt >= max_move_attempts:
+                            raise
+                        # For other exceptions, also retry
+                        wait_time = move_attempt * 2
+                        print(f"Move failed (attempt {move_attempt}/{max_move_attempts}): {e}")
+                        print(f"Waiting {wait_time}s before retry...")
+                        time.sleep(wait_time)
 
-            if not move_successful:
-                raise Exception(f"Failed to move the page after {max_move_attempts} attempts")
+                if not move_successful:
+                    raise Exception(f"Failed to move the page after {max_move_attempts} attempts")
+        finally:
+            _release_notion_official_lock(lock_fd)
         self.rename_page_via_api(duplicated_page_id, child_name)
         return f"https://www.notion.so/{duplicated_page_id.replace('-', '')}"
         


### PR DESCRIPTION
## Summary

Fixes the `invalid_grant: Grant not found` failure mode that all
Notion-using tasks eventually hit: agents do a refresh, Notion rotates
the refresh_token, but the rotated token only lives in the container's
ephemeral filesystem and is lost on container exit, leaving the host's
on-disk token permanently invalidated for every subsequent task.

Two-part fix, contained to three files:

- **Bind-mount** `configs/.mcp-auth` into each task container's
  `/workspace/configs/.mcp-auth` so mcp-remote's rotated-token writes
  persist back to host disk (`scripts/run_single_decoupled.sh` and
  `scripts/run_single_containerized.sh`).
- **Flock** the `notion_official` MCP server context in the page
  duplicator so concurrent task preprocesses can't race rotation.

Also includes a small `docker cp` regression fix: the new bind mount
causes Docker to auto-create `/workspace/configs` as the mount-point
parent, so the existing `docker cp configs container:/workspace/configs`
would land files at `/workspace/configs/configs/*` and break
`configs.global_configs` imports. Switched the directory case to
`mkdir -p dest` + `docker cp src/. dest/` (the "contents only" form),
which is idempotent regardless of whether dest pre-exists.

The shared flock only protects the duplicator's `notion_official` MCP
(preprocess for `notion_remove_and_duplicate`). Runtime notion tool
calls go through `configs/mcp_servers/notion.yaml` + the static
`ntn_*` integration secret — no OAuth, no rotation — and are unaffected.

## Root cause

Notion's hosted MCP rotates refresh tokens on use
([docs](https://developers.notion.com/guides/mcp/build-mcp-client): _"When
the client uses one, the other is invalidated and a new refresh token is
issued."_). mcp-remote-0.1.16 correctly writes rotated tokens back to
its config dir on disk — but our task containers had that dir as a
one-way `docker cp` snapshot, so rotated tokens landed on the
container's ephemeral overlay FS and were discarded on exit.

## Test plan

- [ ] Run a single notion-* task back-to-back twice; second run should
      not fail at preprocess with `Timed out while waiting for response
      to ClientRequest`.
- [ ] Inspect `configs/.mcp-auth/mcp-remote-0.1.16/*_tokens.json` mtime
      on the host after a notion task — should be recent.
- [ ] Verify non-notion task containers still launch cleanly (cp pattern
      change is backward-compatible).
- [ ] Run two notion tasks in parallel; the second should serialize at
      the flock and proceed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)