### PR TITLE
Update hk-top-conf GT for Paper Copilot data change

### DIFF
--- a/tasks/finalpool/hk-top-conf/README.md
+++ b/tasks/finalpool/hk-top-conf/README.md
@@ -5,3 +5,15 @@ To complete this task, the model needs to find papercopilot and use the hover to
 SOME CONCERNS
 
 Currently, the model is not good at using the hover tool, and it is almost impossible to accomplish this task by other means.
+
+DATA SNAPSHOT NOTE
+
+The original ground truth was computed against Paper Copilot data from around 2025-08. A later Paper Copilot data commit changed the reproducible counts:
+
+- Repository: https://github.com/papercopilot/paperlists
+- Commit: d4c51fa4698b270690a237f03c3fc2901a1f4959
+- Commit time: 2025-08-30 20:52:59 -0700
+- Commit message: update iclr25
+- Affected file: iclr/iclr2025.json
+
+This commit changes ICLR 2025 affiliation indexing for several papers with empty first-author affiliation fields. It does not reduce the total number of accepted ICLR 2025 papers, and the relevant ICML 2024 and NeurIPS 2024 files had no later changes for this task. Under the task's first-author-affiliation counting setup, the later data reduces the ICLR 2025 contribution by 6 papers for HKUST and 4 papers for CUHK, with HKU unchanged. The checked-in ground truth accounts for this later Paper Copilot data change.

--- a/tasks/finalpool/hk-top-conf/groundtruth_workspace/result.md
+++ b/tasks/finalpool/hk-top-conf/groundtruth_workspace/result.md
@@ -1,5 +1,5 @@
 | University                                     | Poster | Spotlight | Oral | Total |
 | ---------------------------------------------- | ------ | --------- | ---- | ----- |
-| Hong Kong University of Science and Technology | 113    | 9         | 2    | 124   |
-| Chinese University of Hong Kong                | 107    | 7         | 2    | 116   |
+| Hong Kong University of Science and Technology | 108    | 8         | 2    | 118   |
+| Chinese University of Hong Kong                | 105    | 5         | 2    | 112   |
 | University of Hong Kong                        | 52     | 5         | 0    | 57    |


### PR DESCRIPTION
Summary: Update hk-top-conf ground truth to account for Paper Copilot commit d4c51fa4698b270690a237f03c3fc2901a1f4959. The commit time is 2025-08-30 20:52:59 -0700, message is 'update iclr25', and the affected file is iclr/iclr2025.json. This only affects ICLR 2025 affiliation indexing for this task; ICML 2024 and NeurIPS 2024 have no later relevant changes. GT changes: HKUST 113/9/2/124 -> 108/8/2/118; CUHK 107/7/2/116 -> 105/5/2/112; HKU unchanged at 52/5/0/57. Tests not run; documentation and groundtruth-only change.