### PR TITLE
Bug fixes: canvas (4) + woocommerce-new-product (1)

### DIFF
--- a/tasks/finalpool/canvas-arrange-exam/evaluation/check_local.py
+++ b/tasks/finalpool/canvas-arrange-exam/evaluation/check_local.py
@@ -28,25 +28,38 @@ def _proctor_tokens(raw):
 
 
 def proctor_match(agent_val, ground_val):
-    """Compare proctor names.
+    """Compare proctor names with bidirectional token-subset match.
 
-    Canvas exposes the full instructor name, so when GT carries the full
-    name the agent must too — short names lose information available on
-    the platform.  Rule: GT's tokens must all appear in the agent's tokens
-    (after stripping the 'Professor' honorific on either side).  This
-    means:
-      - GT 'Debra Flores' requires agent to contain both 'debra' AND 'flores'.
-        Agent 'Debra Flores' or 'Professor Debra Flores' passes; 'Debra' alone
-        fails.
-      - GT 'Smith' (single-token, used for 'Professor Smith' replacement cases)
-        requires only 'smith' — agent 'Smith' or 'Professor Smith' passes.
+    Either side's token set being a subset of the other side passes.
+
+    Why bidirectional (not just ``GT tokens ⊆ agent tokens``):
+    the natural Canvas API path an agent uses to enumerate course
+    instructors is ``GET /api/v1/accounts/{id}/courses?include[]=teachers``,
+    whose per-teacher payload exposes ONLY ``display_name`` (the equivalent
+    of ``short_name`` — e.g. 'Debra', 'Steven', 'Christopher') — NO ``name``
+    field is returned.  To get the full instructor name an agent has to
+    make a separate ``GET /api/v1/courses/{id}/users?enrollment_type[]=teacher``
+    call, which is a less-obvious endpoint to reach for first.  The
+    final-exam announcement text doesn't restate the proctor name either
+    (it just signs off as 'Course Instructor').  So agents that follow
+    the natural API path end up writing 'Debra' while GT carries
+    'Debra Flores' — a reasonable agent choice that the previous
+    strict-on-agent rule (``g <= a``) false-failed.
+
+    Bidirectional acceptance handles every legitimate case:
+      - GT 'Debra Flores', agent 'Debra'              -> a ⊆ g  -> pass
+      - GT 'Debra Flores', agent 'Debra Flores'       -> equal -> pass
+      - GT 'Debra Flores', agent 'Professor Debra Flores' -> g ⊆ a -> pass
+        (after stripping 'Professor')
+      - GT 'Smith',        agent 'Professor Smith'    -> g ⊆ a -> pass
+      - GT 'Debra Flores', agent 'Smith'              -> neither subset -> fail (correct)
     """
     a = _proctor_tokens(agent_val)
     g = _proctor_tokens(ground_val)
     if not a or not g:
         # Fall back to TBD-string equality if either side has no real tokens
         return str(agent_val).strip().lower() == str(ground_val).strip().lower()
-    return g <= a
+    return g <= a or a <= g
 
 def check_local(agent_workspace: str, groundtruth_workspace: str):
     """

--- a/tasks/finalpool/canvas-list-test/preprocess/setup_courses_with_mcp.py
+++ b/tasks/finalpool/canvas-list-test/preprocess/setup_courses_with_mcp.py
@@ -849,24 +849,31 @@ class CanvasCourseSetup:
         """Delete a course from Canvas"""
         try:
             async with aiohttp.ClientSession() as session:
-                # First, conclude the course (required before deletion)
+                # The local Canvas mock at port 10001 honors course
+                # conclude/delete only via the HTTP DELETE method with
+                # body {"event": "..."}.  A PUT to the same URL returns
+                # 200/204 but is silently treated as a no-op course update,
+                # leaving workflow_state unchanged — the strict readback
+                # in delete_configured_courses then flags every "deleted"
+                # course as "remaining" and preprocess fails.  Use
+                # session.delete() so the mock actually performs the action.
                 conclude_url = f"{self.base_url}/api/v1/courses/{course_id}"
                 conclude_data = {"event": "conclude"}
-                
-                async with session.put(conclude_url, headers=self.headers, json=conclude_data) as response:
+
+                async with session.delete(conclude_url, headers=self.headers, json=conclude_data) as response:
                     if 200 <= response.status < 300:
                         logger.info(f"Concluded course: {course_name} (ID: {course_id})")
                     else:
                         logger.warning(f"Failed to conclude course {course_name}: {response.status}")
-                
+
                 # Wait a moment for the conclude operation to complete
                 await asyncio.sleep(1)
-                
-                # Try to delete the course using the event parameter
+
+                # Now actually delete via DELETE method (see comment above).
                 delete_url = f"{self.base_url}/api/v1/courses/{course_id}"
                 delete_data = {"event": "delete"}
-                
-                async with session.put(delete_url, headers=self.headers, json=delete_data) as response:
+
+                async with session.delete(delete_url, headers=self.headers, json=delete_data) as response:
                     if 200 <= response.status < 300:
                         logger.info(f"Deleted course: {course_name} (ID: {course_id})")
                         return True

--- a/tasks/finalpool/woocommerce-new-product/preprocess/setup_new_product_data.py
+++ b/tasks/finalpool/woocommerce-new-product/preprocess/setup_new_product_data.py
@@ -293,7 +293,12 @@ class NewProductEmailSetupV2:
                 "short_description": "Flagship wearable device",
                 "categories": [{"id": categories.get("Electronics")}] if categories.get("Electronics") else [],
                 "meta_data": [
-                    {"key": "launch_date", "value": "2025-10-01"},
+                    # Dynamic launch_date relative to preprocess time so the
+                    # grader's "next 30 days" window check is meaningful.
+                    # Previously a static 2025 date that was perpetually in
+                    # the past; the grader masked the bug by treating every
+                    # draft/pending product as new regardless of launch_date.
+                    {"key": "launch_date", "value": (current_date + timedelta(days=10)).strftime("%Y-%m-%d")},
                     {"key": "pre_order_discount", "value": "10"},
                     {"key": "product_type", "value": "new_product"}
                 ],
@@ -309,7 +314,7 @@ class NewProductEmailSetupV2:
                 "short_description": "Ultimate audio experience",
                 "categories": [{"id": categories.get("Electronics")}] if categories.get("Electronics") else [],
                 "meta_data": [
-                    {"key": "launch_date", "value": "2025-09-15"},
+                    {"key": "launch_date", "value": (current_date + timedelta(days=18)).strftime("%Y-%m-%d")},
                     {"key": "pre_order_discount", "value": "15"},
                     {"key": "product_type", "value": "new_product"}
                 ],
@@ -325,7 +330,7 @@ class NewProductEmailSetupV2:
                 "short_description": "Make your home smarter",
                 "categories": [{"id": categories.get("Smart Home")}] if categories.get("Smart Home") else [],
                 "meta_data": [
-                    {"key": "launch_date", "value": "2025-09-20"},
+                    {"key": "launch_date", "value": (current_date + timedelta(days=25)).strftime("%Y-%m-%d")},
                     {"key": "pre_order_discount", "value": "20"},
                     {"key": "product_type", "value": "new_product"}
                 ],

--- a/utils/app_specific/canvas/api_client.py
+++ b/utils/app_specific/canvas/api_client.py
@@ -230,23 +230,19 @@ class CanvasAPI:
         params = {'per_page': 100}  # Request more items per page
         if include_deleted:
             params['include'] = ['deleted']
-        
+
         all_courses = []
-        
-        # Try user courses first
-        page = 1
-        while True:
-            params['page'] = page
-            result = self._make_request('GET', 'courses', params=params)
-            if not result or len(result) == 0:
-                break
-            all_courses.extend(result)
-            if len(result) < params['per_page']:
-                break
-            page += 1
-        
-        # If we're admin and no user courses found, try account courses
-        if len(all_courses) == 0 and account_id is not None:
+
+        # When account_id is given, query the account-courses endpoint
+        # directly.  GET /api/v1/courses only returns courses the calling
+        # user is enrolled in; for admin/preprocess flows that just
+        # created a course but did NOT enroll the admin (e.g.
+        # canvas-homework-grader-python enrolls only Teresa Torres as
+        # teacher), the user-courses list is missing the new course and
+        # the previous "fallback only when empty" logic silently skipped
+        # the account endpoint because OTHER concurrent tasks had
+        # already enrolled the admin in their courses.
+        if account_id is not None:
             try:
                 page = 1
                 while True:
@@ -258,10 +254,23 @@ class CanvasAPI:
                     if len(result) < params['per_page']:
                         break
                     page += 1
-            except:
-                # Fall back to user courses if account access fails
-                pass
-        
+                return all_courses
+            except Exception:
+                # Fall through to user-courses on account access errors.
+                all_courses = []
+
+        # Non-admin path: list courses the calling user is enrolled in.
+        page = 1
+        while True:
+            params['page'] = page
+            result = self._make_request('GET', 'courses', params=params)
+            if not result or len(result) == 0:
+                break
+            all_courses.extend(result)
+            if len(result) < params['per_page']:
+                break
+            page += 1
+
         return all_courses
     
     def publish_course(self, course_id: int) -> bool:

--- a/utils/app_specific/canvas/api_client.py
+++ b/utils/app_specific/canvas/api_client.py
@@ -242,6 +242,13 @@ class CanvasAPI:
         # the previous "fallback only when empty" logic silently skipped
         # the account endpoint because OTHER concurrent tasks had
         # already enrolled the admin in their courses.
+        # Pagination note: do NOT short-circuit on
+        # ``len(result) < params['per_page']`` — the local Canvas mock at
+        # port 10001 caps the actual page size at 50 regardless of the
+        # ``per_page`` query parameter.  With per_page=100 requested, the
+        # mock returns 50; that's less than 100, so the early-break would
+        # stop after page 1, silently dropping every course on page 2+.
+        # Page strictly until an empty response.
         if account_id is not None:
             try:
                 page = 1
@@ -251,8 +258,6 @@ class CanvasAPI:
                     if not result or len(result) == 0:
                         break
                     all_courses.extend(result)
-                    if len(result) < params['per_page']:
-                        break
                     page += 1
                 return all_courses
             except Exception:
@@ -267,8 +272,6 @@ class CanvasAPI:
             if not result or len(result) == 0:
                 break
             all_courses.extend(result)
-            if len(result) < params['per_page']:
-                break
             page += 1
 
         return all_courses


### PR DESCRIPTION
Five discrete bug fixes against `toolathlon-tasks-verified-toreview`, ordered by commit:

## 1. `canvas-list-test`: course conclude/delete uses wrong HTTP method (`d3f9f4b5`)

`tasks/finalpool/canvas-list-test/preprocess/setup_courses_with_mcp.py:delete_course` uses `session.put(url, json={"event": "..."})`. On the local Canvas mock at port 10001, this returns 200/204 but is **treated as a no-op course update** — `workflow_state` never changes. The strict readback added by `2210074a` then flags every "deleted" course as still present and preprocess fails with `Configured-course cleanup failed`.

Empirical probe against the mock:
```
PUT  /api/v1/courses/{id}  {"event": "delete"}              -> 200, course unchanged
PUT  /api/v1/courses/{id}  {"course":{"event":"delete"}}    -> 204, course unchanged
DELETE /api/v1/courses/{id} {"event": "delete"}             -> 200 {"delete": true}, course GONE
DELETE /api/v1/courses/{id} {"event": "conclude"}           -> 200 {"conclude": true}, state=completed
```

Fix: switch the inline `delete_course` from `session.put` → `session.delete` for both the conclude and delete steps.

## 2. `woocommerce-new-product`: static 2025 launch_dates → dynamic, relative to preprocess time (`1e07893d`)

`preprocess/setup_new_product_data.py` had three hardcoded `launch_date` strings (2025-10-01, 2025-09-15, 2025-09-20) that have been in the past for many months. The grader's "next 30 days" window check never matched, and a `has_future_launch = True` override silently saved the day by treating every draft/pending product as new regardless of launch_date.

Fix: compute launch_date from `datetime.now()` at preprocess time (the `current_date` variable already exists a few lines above):
- Smart Watch Pro Max: `current_date + 10 days`
- Wireless Noise-Canceling Headphones Ultra: `current_date + 18 days`
- Smart Home Control Hub: `current_date + 25 days`

All three sit inside the 30-day window so the spec is meaningful and the `has_future_launch = True` override becomes dead code.

## 3. `CanvasAPI.list_courses`: wrong-endpoint when admin (`4b967330`)

`utils/app_specific/canvas/api_client.py:list_courses(account_id=1)` queried the calling user's *enrolled-courses* list first (`GET /courses`) and only fell back to `/accounts/{id}/courses` if that list was empty:

```python
if len(all_courses) == 0 and account_id is not None:   # only when empty
    # query /accounts/{id}/courses
```

On a multi-task Canvas instance the admin is concurrently enrolled in many courses created by other tasks, so the user-courses path is rarely empty — and the new course just created by the calling task (where the admin was not enrolled) never appears.

Symptom: `canvas-homework-grader-python` preprocess (`extract_student_ids.py`) repeatedly failed with `❌ No CS5123 course found` despite the preceding step having just created CS5123. Also affects `canvas-arrange-exam`.

Fix: when `account_id` is provided, query `/accounts/{id}/courses` **directly**. Fall through to user-courses only on access errors.

## 4. `CanvasAPI.list_courses`: pagination overshoots on mock per-page cap (`70b46af7`)

After fix #3, list_courses still returned only 50 courses against the local mock and missed CS5123 again. The mock at port 10001 caps the actual page size at **50** regardless of the `per_page` query parameter. Both pagination loops had:

```python
if len(result) < params['per_page']: break   # 50 < 100 → break after page 1
```

CS5123 entries sat on page 2 (ids 80-84) and were never fetched.

Fix: drop the early-break optimization on both pagination loops and page strictly until an empty response.

## 5. `canvas-arrange-exam`: bidirectional proctor name match (`722609ef`)

Followup to a Jun 25 sandbox change that tightened the proctor grader to `GT tokens ⊆ agent tokens`. That direction is unfair to agents because the natural Canvas MCP path returns only short names:

- `canvas_list_courses` (the only course-listing MCP tool the agent's student-role token can use) returns each teacher as `{id, display_name, avatar_image_url, html_url}` — **only `display_name`** (= `short_name`), no `name` field.
- `canvas_list_account_courses` and `canvas_get_course` return `401 not authorized` for the agent's token.
- The final-exam announcement text doesn't restate the proctor name either — it just signs off as "Course Instructor".

So an agent that follows the spec literally ("the proctor is the course instructor") and uses `canvas_list_courses` ends up writing `'Debra'` while GT carries `'Debra Flores'` — entirely reasonable, but the strict-direction grader false-failed it (7/9 mismatches at 22.2% match rate).

Fix: accept either direction of token-subset match (`g <= a or a <= g`). Behavior matrix:

| Agent | GT | Result |
|---|---|---|
| `'Debra'` | `'Debra Flores'` | pass (was fail) |
| `'Debra Flores'` | `'Debra Flores'` | pass |
| `'Professor Debra Flores'` | `'Debra Flores'` | pass |
| `'Smith'` | `'Smith'` | pass |
| `'Professor Smith'` | `'Smith'` | pass |
| `'Mary'` | `'Debra Flores'` | fail (correctly rejects wrong proctor) |
| `'Debra Smith'` | `'Debra Flores'` | fail (correctly rejects partial-wrong) |

## Test plan
- [x] `d3f9f4b5` verified e2e on host (port 8089): cold + warm canvas-list-test preprocess both reach `ready`; warm second run actually deletes the prior run's 14 courses before re-creating them.
- [x] `4b967330` + `70b46af7` verified e2e on host: `canvas-homework-grader-python` and `canvas-arrange-exam` preprocess both reach `ready` (40s and 146s respectively) after the fixes; previously both failed within ~30s with `❌ No CS5123 course found` for the homework task.
- [x] `4b967330` + `70b46af7` host unit-test: `CanvasAPI.list_courses(account_id=1)` returns 84 courses across 2 pages including all CS5123 entries (vs 50 / 0 CS5123 before).
- [x] `722609ef` verified: synthesized agent_workspace with short-name proctors (mimicking what `canvas_list_courses` returns) → grader 9/9 perfect match (vs 2/9 with the strict grader). 10 unit cases covering full/short/honorific/wrong forms all match expectations.
- [ ] Reviewer: please confirm behavior in your Canvas-mock setup — if your mock's `PUT /courses/{id}` with bare `{"event": "..."}` body DOES delete (different mock impl), fix #1 is a no-op there but is necessary on the published image at `lockon0927/toolathlon-task-image:1016beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)