### PR TITLE
fix(mcp): use npx --prefer-offline for rail_12306 to avoid cold-start registry revalidation timeouts

### DIFF
--- a/configs/mcp_servers/12306.yaml
+++ b/configs/mcp_servers/12306.yaml
@@ -7,6 +7,12 @@ params:
   command: npx
   args:
     - "-y"
+    # The task image already ships 12306-mcp in its npm/npx cache. --prefer-offline
+    # makes npx use that cached package and skip the network revalidation request to
+    # the registry, which under high worker concurrency (20-32 containers at once)
+    # can hang and cause intermittent cold-start timeouts. On a cache miss npx falls
+    # back to the network automatically, so this never causes a failure.
+    - "--prefer-offline"
     - "12306-mcp"
   cwd: "${agent_workspace}"
 cache_tools_list: true


### PR DESCRIPTION
## Problem
`configs/mcp_servers/12306.yaml` runs `rail_12306` as an `npx -y 12306-mcp` stdio server. The task image already ships the `12306-mcp` package in its npm/npx cache, but plain `npx` still issues a network revalidation request to the registry on startup. Under high worker concurrency (20-32 fresh containers starting at once), that request can hang, making the first `list_tools()` exceed the 20s session timeout. The connection then fails, retries cascade, and the run reports `Only N servers connected, expected M` — causing tasks to be judged null. It is intermittent by nature: when the network is fast the revalidation returns quickly and 20s is enough.

## Fix
Add `--prefer-offline` to the npx args so npx uses the cached package and skips the registry revalidation. On a cache miss npx automatically falls back to the network, so this never introduces a failure. `client_session_timeout_seconds` is left unchanged at 20.

## Verification
Tested in `lockon0927/toolathlon-task-image:1016beta`:
- The flag order `-y --prefer-offline 12306-mcp` is accepted by npx (no "unknown option").
- Startup is unchanged/slightly faster (~4s → ~3s with normal network).
- With `docker run --network none`, npx still resolves `12306-mcp` from the image cache and launches in ~2s, confirming no registry fetch is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
