### PR TITLE
Fix decoupled-mode PermissionError on Linux; keep the model API key out of argv, logs, and private-mode payloads

### DIFF
--- a/eval_client.py
+++ b/eval_client.py
@@ -730,7 +730,7 @@ def run(
     ),
     api_key: Optional[str] = typer.Option(
         None,
-        help="API key for authentication. It is required for public mode, and ignored for private mode. So in private mode please set OPENAI_API_KEY environment variable if your endpoint requires it."
+        help="API key for authentication. It is required for public mode. In private mode it is not sent to the evaluation server; it is forwarded to the local WebSocket client, which otherwise falls back to the TOOLATHLON_OPENAI_API_KEY or OPENAI_API_KEY environment variable."
     ),
     workers: int = typer.Option(
         10,

--- a/eval_client.py
+++ b/eval_client.py
@@ -529,7 +529,7 @@ async def private_worker(
                 sys.executable, "simple_client_ws.py",
                 "--server-url", ws_server_url,
                 "--llm-base-url", vllm_url,
-                "--llm-api-key", vllm_api_key or "",
+                *(["--llm-api-key", vllm_api_key] if vllm_api_key else []),
                 "--job-id", job_id,  # Pass job_id for authentication
                 stdout=log_f,
                 stderr=asyncio.subprocess.STDOUT
@@ -984,7 +984,9 @@ def run(
                 "client_version": CLIENT_VERSION,  # Send client version for compatibility check
                 "mode": mode,
                 "base_url": base_url,
-                "api_key": api_key,
+                # The server never reads the key for private jobs; inference
+                # is proxied through the local WebSocket client.
+                "api_key": api_key if mode == "public" else None,
                 "model_name": model_name,
                 "workers": workers,
                 "custom_job_id": job_id,  # Pass custom job_id if provided
@@ -1132,14 +1134,18 @@ from eval_client import public_worker
 asyncio.run(public_worker('{server_url}', '{final_job_id}', '{output_dir}', {force_redownload}, {trust_env_in_httpx}))
 """
     else:  # private
-        api_key_arg = f"'{api_key}'" if api_key else "None"
+        # The key is handed to the worker via its environment, not its argv.
         worker_code = f"""
 import asyncio
 import sys
 sys.path.insert(0, '{os.path.abspath(os.path.dirname(__file__))}')
 from eval_client import private_worker
-asyncio.run(private_worker('{server_url}', '{final_job_id}', '{client_id}', '{base_url}', {api_key_arg}, {ws_proxy_port}, '{output_dir}', {force_redownload}, {trust_env_in_httpx}))
+asyncio.run(private_worker('{server_url}', '{final_job_id}', '{client_id}', '{base_url}', None, {ws_proxy_port}, '{output_dir}', {force_redownload}, {trust_env_in_httpx}))
 """
+
+    worker_env = os.environ.copy()
+    if mode == "private" and api_key:
+        worker_env["TOOLATHLON_OPENAI_API_KEY"] = api_key
 
     # Start detached background process
     process = subprocess.Popen(
@@ -1148,7 +1154,8 @@ asyncio.run(private_worker('{server_url}', '{final_job_id}', '{client_id}', '{ba
         stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,
         start_new_session=True,
-        cwd=os.getcwd()
+        cwd=os.getcwd(),
+        env=worker_env
     )
 
     typer.echo(f"\n✓ Background worker started (PID: {process.pid})")

--- a/scripts/decoupled/tests/test_run_single_decoupled_isolation.py
+++ b/scripts/decoupled/tests/test_run_single_decoupled_isolation.py
@@ -40,9 +40,14 @@ class DecoupledIsolationRunnerTests(unittest.TestCase):
             re.search(r"(?m)^\s*exit\b", self.script[host_exit:restore])
         )
 
+        # No stop/start of the task container between the host loop and the
+        # evaluation, with or without options such as `-t 0` — evaluator-
+        # visible task services must stay up.  cleanup()'s quiesce/restart
+        # lives outside this segment.
         live_container_segment = self.script[host_exit:evaluation]
-        self.assertNotIn(' stop "$CONTAINER_NAME"', live_container_segment)
-        self.assertNotIn(' start "$CONTAINER_NAME"', live_container_segment)
+        self.assertIsNone(
+            re.search(r"\$CONTAINER_RUNTIME (stop|start)\b", live_container_segment)
+        )
 
     def test_evaluator_uses_consumed_private_bundle_and_trusted_inputs(self) -> None:
         evaluation = self.position("# Step 6: Container evaluation")
@@ -91,7 +96,7 @@ class DecoupledIsolationRunnerTests(unittest.TestCase):
         self.assertEqual(self.script.count("task_artifact_guard restore"), 1)
         cleanup_start = self.position("cleanup() {")
         container_stop = self.position(
-            '$CONTAINER_RUNTIME stop "$CONTAINER_NAME"', cleanup_start
+            '$CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME"', cleanup_start
         )
         stash_cleanup = self.position(
             "task_artifact_guard cleanup", container_stop

--- a/scripts/run_single_containerized.sh
+++ b/scripts/run_single_containerized.sh
@@ -128,12 +128,12 @@ echo "Container name: $CONTAINER_NAME"
 # --- BEGIN: Detect and propagate TOOLATHLON_OPENAI env vars from host to container ---
 EXTRA_ENV_ARGS=()
 if [ ! -z "${TOOLATHLON_OPENAI_BASE_URL+x}" ]; then
-    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL=${TOOLATHLON_OPENAI_BASE_URL}")
+    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL")
     echo "Detected host TOOLATHLON_OPENAI_BASE_URL, will pass into container"
 fi
 
 if [ ! -z "${TOOLATHLON_OPENAI_API_KEY+x}" ]; then
-    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY=${TOOLATHLON_OPENAI_API_KEY}")
+    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY")
     echo "Detected host TOOLATHLON_OPENAI_API_KEY, will pass into container"
 fi
 

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -228,12 +228,12 @@ esac
 
 if [ "$USE_UNIFIED_MODEL_ENV" = true ]; then
     if [ ! -z "${TOOLATHLON_OPENAI_BASE_URL+x}" ]; then
-        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL=${TOOLATHLON_OPENAI_BASE_URL}")
+        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL")
         echo "Detected host TOOLATHLON_OPENAI_BASE_URL, will pass into container"
     fi
 
     if [ ! -z "${TOOLATHLON_OPENAI_API_KEY+x}" ]; then
-        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY=${TOOLATHLON_OPENAI_API_KEY}")
+        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY")
         echo "Detected host TOOLATHLON_OPENAI_API_KEY, will pass into container"
     fi
 else

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -263,7 +263,9 @@ CURRENT_CONTAINER_BUNDLE=""
 # is captured right before preprocess runs as container root, and
 # DUMPS_RESTORE_PENDING stays 1 until the tree has been handed back, so
 # cleanup() can finish a restoration the main flow never reached (preprocess
-# failure, SIGINT/SIGTERM).
+# failure, SIGINT/SIGTERM).  On the interrupted path cleanup() must quiesce
+# the container before restoring: the exec'd preprocess can outlive its
+# local client and keep writing (see the pending block in cleanup()).
 DUMPS_OWNER=""
 DUMPS_RESTORE_PENDING=0
 
@@ -287,21 +289,38 @@ cleanup() {
         CURRENT_CONTAINER_BUNDLE=""
     fi
 
-    # Finish any pending ownership restoration while the container can still
-    # service exec calls, i.e. before it is stopped.  Best-effort: this covers
-    # preprocess failures and SIGINT/SIGTERM interruptions.
+    # Finish any pending ownership restoration.  Killing the local exec
+    # CLIENT (Ctrl-C, or run_parallel.py's process-group SIGTERM on task
+    # timeout) does not kill the exec'd process inside the container: it
+    # keeps writing root-owned files to the bind mount.  So quiesce first --
+    # stopping the container tears down its PID namespace and every writer
+    # in it -- then restart the now-inert container (its entrypoint is a
+    # plain `sleep`, and reusing the same container keeps the user-namespace
+    # mapping DUMPS_OWNER was captured under) and only then chown.
+    #
+    # The stop comes FIRST and uses -t 0: run_parallel.py escalates its
+    # SIGTERM to SIGKILL after only 3 seconds, PID 1 (`sleep`) can never
+    # honor a graceful stop anyway, and the daemon completes an accepted
+    # stop even if this script is killed before it returns.  Worst case a
+    # truncated cleanup leaves files with the wrong owner but no live
+    # writer, and the next successful run's full-tree hand-off chown
+    # self-heals them.
     if [ "$DUMPS_RESTORE_PENDING" = "1" ]; then
-        if restore_dumps_ownership >/dev/null 2>&1; then
+        $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        if $CONTAINER_RUNTIME start "$CONTAINER_NAME" >/dev/null 2>&1 \
+            && restore_dumps_ownership >/dev/null 2>&1; then
             echo "  ✓ Restored output ownership: $output_folder"
         else
             echo "  Warning: could not restore output ownership: $output_folder" >&2
         fi
     fi
 
-    # Stop and remove container if exists
+    # Stop and remove container if exists.  -t 0 also here: nothing inside
+    # can use a graceful stop (see above), so the default 10s grace is pure
+    # added latency on every exit path.
     if $CONTAINER_RUNTIME ps -aq --filter "name=$CONTAINER_NAME" 2>/dev/null | grep -q .; then
         echo "  Stopping and removing container: $CONTAINER_NAME"
-        $CONTAINER_RUNTIME stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 || true
         $CONTAINER_RUNTIME rm "$CONTAINER_NAME" >/dev/null 2>&1 || true
         echo "  ✓ Container stopped and removed"
     fi

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -678,6 +678,20 @@ if [ -z "$CURRENT_CONTAINER_BUNDLE" ]; then
     exit 1
 fi
 
+# Owner of the bind-mounted output tree as seen from inside the container's
+# user namespace: the invoking host user on rootful Docker/Podman, container
+# root under rootless Podman. Captured before preprocess (which runs as
+# container root) so ownership can be restored afterwards.
+if ! DUMPS_OWNER=$($CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+    stat -c '%u:%g' /workspace/dumps); then
+    echo "✗ Could not determine output ownership inside the container" >&2
+    exit 1
+fi
+if [[ ! "$DUMPS_OWNER" =~ ^[0-9]+:[0-9]+$ ]]; then
+    echo "✗ Invalid output ownership reported by container: $DUMPS_OWNER" >&2
+    exit 1
+fi
+
 PREPROCESS_ARGS=(
     uv run python -m scripts.decoupled.container_preprocess
     --eval_config "$eval_config"
@@ -707,6 +721,15 @@ if [ $PREPROCESS_EXIT_CODE -ne 0 ]; then
     exit $PREPROCESS_EXIT_CODE
 fi
 echo "✓ Preprocess completed"
+
+# Preprocess runs as container root. Restore the output tree to its
+# pre-preprocess owner in the container's user namespace, preserving host
+# writability under both rootful runtimes and rootless Podman.
+if ! $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+    chown -R -- "$DUMPS_OWNER" /workspace/dumps; then
+    echo "✗ Failed to hand output ownership to the host agent" >&2
+    exit 1
+fi
 
 if ! $CONTAINER_RUNTIME cp \
     "$CONTAINER_NAME:$CURRENT_CONTAINER_BUNDLE" \

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -259,6 +259,20 @@ TRUSTED_BUNDLE_FILE=""
 HOST_AGENT_BUNDLE_FILE=""
 CURRENT_CONTAINER_BUNDLE=""
 
+# Ownership-restoration state for the bind-mounted output tree.  DUMPS_OWNER
+# is captured right before preprocess runs as container root, and
+# DUMPS_RESTORE_PENDING stays 1 until the tree has been handed back, so
+# cleanup() can finish a restoration the main flow never reached (preprocess
+# failure, SIGINT/SIGTERM).
+DUMPS_OWNER=""
+DUMPS_RESTORE_PENDING=0
+
+restore_dumps_ownership() {
+    $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+        chown -R -- "$DUMPS_OWNER" /workspace/dumps || return 1
+    DUMPS_RESTORE_PENDING=0
+}
+
 # Cleanup function
 cleanup() {
     cleanup_exit_code=$?
@@ -271,6 +285,17 @@ cleanup() {
         $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
             rm -f -- "$CURRENT_CONTAINER_BUNDLE" >/dev/null 2>&1 || true
         CURRENT_CONTAINER_BUNDLE=""
+    fi
+
+    # Finish any pending ownership restoration while the container can still
+    # service exec calls, i.e. before it is stopped.  Best-effort: this covers
+    # preprocess failures and SIGINT/SIGTERM interruptions.
+    if [ "$DUMPS_RESTORE_PENDING" = "1" ]; then
+        if restore_dumps_ownership >/dev/null 2>&1; then
+            echo "  ✓ Restored output ownership: $output_folder"
+        else
+            echo "  Warning: could not restore output ownership: $output_folder" >&2
+        fi
     fi
 
     # Stop and remove container if exists
@@ -691,6 +716,7 @@ if [[ ! "$DUMPS_OWNER" =~ ^[0-9]+:[0-9]+$ ]]; then
     echo "✗ Invalid output ownership reported by container: $DUMPS_OWNER" >&2
     exit 1
 fi
+DUMPS_RESTORE_PENDING=1
 
 PREPROCESS_ARGS=(
     uv run python -m scripts.decoupled.container_preprocess
@@ -716,20 +742,26 @@ fi
 PREPROCESS_EXIT_CODE=$?
 set -e
 
+# Preprocess runs as container root and may have created files in the
+# bind-mounted output tree even when it failed.  Restore the tree to its
+# pre-preprocess owner in the container's user namespace regardless of the
+# preprocess result, so a failed run cannot strand root-owned files that
+# break the next retry or cleanup with the same PermissionError.
+if ! restore_dumps_ownership; then
+    if [ $PREPROCESS_EXIT_CODE -eq 0 ]; then
+        echo "✗ Failed to hand output ownership to the host agent" >&2
+        exit 1
+    fi
+    # Keep the preprocess exit code authoritative; cleanup() retries the
+    # restoration before the container is stopped.
+    echo "Warning: could not restore output ownership after failed preprocess" >&2
+fi
+
 if [ $PREPROCESS_EXIT_CODE -ne 0 ]; then
     echo "✗ Preprocess failed, exit code: $PREPROCESS_EXIT_CODE"
     exit $PREPROCESS_EXIT_CODE
 fi
 echo "✓ Preprocess completed"
-
-# Preprocess runs as container root. Restore the output tree to its
-# pre-preprocess owner in the container's user namespace, preserving host
-# writability under both rootful runtimes and rootless Podman.
-if ! $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
-    chown -R -- "$DUMPS_OWNER" /workspace/dumps; then
-    echo "✗ Failed to hand output ownership to the host agent" >&2
-    exit 1
-fi
 
 if ! $CONTAINER_RUNTIME cp \
     "$CONTAINER_NAME:$CURRENT_CONTAINER_BUNDLE" \

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -283,12 +283,6 @@ cleanup() {
     echo ""
     echo "Performing cleanup..."
 
-    if [ -n "$CURRENT_CONTAINER_BUNDLE" ]; then
-        $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
-            rm -f -- "$CURRENT_CONTAINER_BUNDLE" >/dev/null 2>&1 || true
-        CURRENT_CONTAINER_BUNDLE=""
-    fi
-
     # Finish any pending ownership restoration.  Killing the local exec
     # CLIENT (Ctrl-C, or run_parallel.py's process-group SIGTERM on task
     # timeout) does not kill the exec'd process inside the container: it
@@ -298,21 +292,40 @@ cleanup() {
     # plain `sleep`, and reusing the same container keeps the user-namespace
     # mapping DUMPS_OWNER was captured under) and only then chown.
     #
-    # The stop comes FIRST and uses -t 0: run_parallel.py escalates its
+    # The stop is cleanup's FIRST container operation -- ahead even of the
+    # bundle removal below -- and uses -t 0: run_parallel.py escalates its
     # SIGTERM to SIGKILL after only 3 seconds, PID 1 (`sleep`) can never
     # honor a graceful stop anyway, and the daemon completes an accepted
-    # stop even if this script is killed before it returns.  Worst case a
-    # truncated cleanup leaves files with the wrong owner but no live
-    # writer, and the next successful run's full-tree hand-off chown
+    # stop even if this script is killed before it returns, whereas an exec
+    # needs this client to survive the whole round-trip.  Nothing may spend
+    # the kill window before the stop has been submitted.
+    #
+    # The stop's exit status gates the restoration: `start` returns 0 on an
+    # already-running container, so it proves nothing about the writer --
+    # only a successful stop does.  If the stop fails, skip the chown
+    # entirely rather than hand the tree over under a live writer; the
+    # teardown below retries the stop.  Worst case files are left with the
+    # wrong owner, and the next successful run's full-tree hand-off chown
     # self-heals them.
     if [ "$DUMPS_RESTORE_PENDING" = "1" ]; then
-        $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 || true
-        if $CONTAINER_RUNTIME start "$CONTAINER_NAME" >/dev/null 2>&1 \
+        if $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 \
+            && $CONTAINER_RUNTIME start "$CONTAINER_NAME" >/dev/null 2>&1 \
             && restore_dumps_ownership >/dev/null 2>&1; then
             echo "  ✓ Restored output ownership: $output_folder"
         else
             echo "  Warning: could not restore output ownership: $output_folder" >&2
         fi
+    fi
+
+    # Remove the in-container bundle copy on early exits (the normal flow
+    # discards it right after preprocess).  Best-effort and deliberately
+    # AFTER the quiesce: if the container is not running anymore the exec
+    # fails harmlessly and the unconditional `rm` below destroys the
+    # container filesystem, bundle included.
+    if [ -n "$CURRENT_CONTAINER_BUNDLE" ]; then
+        $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+            rm -f -- "$CURRENT_CONTAINER_BUNDLE" >/dev/null 2>&1 || true
+        CURRENT_CONTAINER_BUNDLE=""
     fi
 
     # Stop and remove container if exists.  -t 0 also here: nothing inside

--- a/simple_client_ws.py
+++ b/simple_client_ws.py
@@ -11,6 +11,7 @@ import asyncio
 import httpx
 import argparse
 import json
+import os
 from datetime import datetime
 from websockets import connect, ConnectionClosedError
 
@@ -318,7 +319,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="WebSocket Proxy Client")
     parser.add_argument("--server-url", required=True, help="Server URL (e.g., http://47.253.6.47:8080)")
     parser.add_argument("--llm-base-url", required=True, help="Real LLM base URL (e.g., https://api.deepseek.com/v1)")
-    parser.add_argument("--llm-api-key", required=True, help="Real LLM API key")
+    parser.add_argument(
+        "--llm-api-key",
+        default=os.environ.get("TOOLATHLON_OPENAI_API_KEY"),
+        required="TOOLATHLON_OPENAI_API_KEY" not in os.environ,
+        help="Real LLM API key; defaults to TOOLATHLON_OPENAI_API_KEY",
+    )
     parser.add_argument("--job-id", required=False, help="Job ID for authentication (required by server)")
 
     args = parser.parse_args()

--- a/simple_client_ws.py
+++ b/simple_client_ws.py
@@ -321,9 +321,11 @@ if __name__ == "__main__":
     parser.add_argument("--llm-base-url", required=True, help="Real LLM base URL (e.g., https://api.deepseek.com/v1)")
     parser.add_argument(
         "--llm-api-key",
-        default=os.environ.get("TOOLATHLON_OPENAI_API_KEY"),
-        required="TOOLATHLON_OPENAI_API_KEY" not in os.environ,
-        help="Real LLM API key; defaults to TOOLATHLON_OPENAI_API_KEY",
+        default=os.environ.get(
+            "TOOLATHLON_OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY", "")
+        ),
+        help="Real LLM API key; defaults to TOOLATHLON_OPENAI_API_KEY, then "
+             "OPENAI_API_KEY, then empty for endpoints without authentication",
     )
     parser.add_argument("--job-id", required=False, help="Job ID for authentication (required by server)")
 

--- a/tests/decoupled/fake_bin/docker
+++ b/tests/decoupled/fake_bin/docker
@@ -10,6 +10,11 @@
 #   FAKE_PREPROCESS_BEHAVIOR  succeed (default) | fail:<code> | hang
 #   FAKE_CHOWN_BEHAVIOR       succeed (default) | fail
 #   FAKE_START_BEHAVIOR       succeed (default) | fail
+#   FAKE_STOP_BEHAVIOR        succeed (default) | fail-once -- the FIRST
+#                             stop exits nonzero WITHOUT stopping anything
+#                             (writer stays alive, `running` stays), like a
+#                             daemon that rejected the request; later stops
+#                             behave normally so teardown still completes
 #   FAKE_DUMPS_OWNER          uid:gid reported for /workspace/dumps
 #                             (default 1000:1000)
 #
@@ -51,6 +56,17 @@ case "$cmd" in
         exit 0
         ;;
     stop)
+        # fail-once models a stop the daemon rejects while the container
+        # keeps running: nothing is killed, `running` stays, and the exit
+        # code is the runner's ONLY hint -- a later `start` still succeeds
+        # (see below), so a runner that ignores this failure would chown
+        # straight into the live writer.
+        if [ "${FAKE_STOP_BEHAVIOR:-succeed}" = "fail-once" ] \
+            && [ ! -e "$STATE/stop_failed_once" ]; then
+            touch "$STATE/stop_failed_once"
+            echo "stop-fail $*" >> "$STATE/events"
+            exit 1
+        fi
         # Tearing down the container kills every process in its PID
         # namespace, including exec'd ones the client abandoned.  Record
         # whether the inner writer was still alive when stop arrived, then
@@ -69,6 +85,9 @@ case "$cmd" in
         exit 0
         ;;
     start)
+        # Like real docker/podman, `start` on an already-running container
+        # is a no-op SUCCESS -- which is exactly why the runner may not use
+        # it as a stopped-state check after a failed stop.
         echo "start $*" >> "$STATE/events"
         case "${FAKE_START_BEHAVIOR:-succeed}" in
             fail)

--- a/tests/decoupled/fake_bin/docker
+++ b/tests/decoupled/fake_bin/docker
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Fake container runtime for the run_single_decoupled.sh regression tests.
+#
+# The stub records every invocation to $FAKE_RUNTIME_STATE/calls.log, keeps
+# coarse container state as marker files (created/running), and appends the
+# events the tests assert on (preprocess-start, chown, stop) to
+# $FAKE_RUNTIME_STATE/events in arrival order.
+#
+# Behavior knobs (environment):
+#   FAKE_PREPROCESS_BEHAVIOR  succeed (default) | fail:<code> | hang
+#   FAKE_CHOWN_BEHAVIOR       succeed (default) | fail
+#   FAKE_DUMPS_OWNER          uid:gid reported for /workspace/dumps
+#                             (default 1000:1000)
+set -u
+
+STATE="${FAKE_RUNTIME_STATE:?FAKE_RUNTIME_STATE must be set}"
+printf '%s\n' "$0 $*" >> "$STATE/calls.log"
+
+cmd="${1:-}"
+[ $# -gt 0 ] && shift
+
+case "$cmd" in
+    run)
+        touch "$STATE/created" "$STATE/running"
+        echo "fakecontainer0123"
+        exit 0
+        ;;
+    ps)
+        # `ps -q` lists running containers, `ps -aq` includes stopped ones.
+        all=false
+        for arg in "$@"; do
+            [ "$arg" = "-aq" ] && all=true
+        done
+        if [ "$all" = true ]; then
+            [ -e "$STATE/created" ] && echo "fakecontainer0123"
+        else
+            [ -e "$STATE/running" ] && echo "fakecontainer0123"
+        fi
+        exit 0
+        ;;
+    stop)
+        echo "stop" >> "$STATE/events"
+        rm -f "$STATE/running"
+        exit 0
+        ;;
+    rm)
+        rm -f "$STATE/created"
+        exit 0
+        ;;
+    cp)
+        exit 0
+        ;;
+    logs)
+        echo "fake container logs"
+        exit 0
+        ;;
+    version)
+        echo "fake runtime version"
+        exit 0
+        ;;
+    exec)
+        # Strip exec options so $1 becomes the container name.
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --env) shift 2 ;;
+                -t|-i|-it|-ti) shift ;;
+                *) break ;;
+            esac
+        done
+        [ $# -gt 0 ] && shift  # container name
+        inner="$*"
+        case "$inner" in
+            "echo "*)
+                echo "container ready"
+                exit 0
+                ;;
+            "mkdir "*|"rm "*|"chmod "*|"bash "*|"which "*)
+                exit 0
+                ;;
+            "kind version")
+                echo "kind v0.20.0 fake"
+                exit 0
+                ;;
+            "docker version"|"podman version")
+                exit 0
+                ;;
+            "mktemp "*)
+                echo "/run/fake-decoupled-bundle.json"
+                exit 0
+                ;;
+            "stat -c "*)
+                echo "${FAKE_DUMPS_OWNER:-1000:1000}"
+                exit 0
+                ;;
+            "chown -R -- "*)
+                echo "$inner" >> "$STATE/events"
+                case "${FAKE_CHOWN_BEHAVIOR:-succeed}" in
+                    fail) exit 1 ;;
+                    *) exit 0 ;;
+                esac
+                ;;
+            *container_preprocess*)
+                echo "preprocess-start" >> "$STATE/events"
+                touch "$STATE/preprocess_started"
+                case "${FAKE_PREPROCESS_BEHAVIOR:-succeed}" in
+                    fail:*)
+                        exit "${FAKE_PREPROCESS_BEHAVIOR#fail:}"
+                        ;;
+                    hang)
+                        sleep 120
+                        exit 0
+                        ;;
+                    *)
+                        exit 0
+                        ;;
+                esac
+                ;;
+            *)
+                echo "unhandled-exec $inner" >> "$STATE/events"
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/tests/decoupled/fake_bin/docker
+++ b/tests/decoupled/fake_bin/docker
@@ -9,8 +9,20 @@
 # Behavior knobs (environment):
 #   FAKE_PREPROCESS_BEHAVIOR  succeed (default) | fail:<code> | hang
 #   FAKE_CHOWN_BEHAVIOR       succeed (default) | fail
+#   FAKE_START_BEHAVIOR       succeed (default) | fail
 #   FAKE_DUMPS_OWNER          uid:gid reported for /workspace/dumps
 #                             (default 1000:1000)
+#
+# Signal-semantics model (matches real docker/podman, verified against
+# rootful Docker 29.x): the local `docker exec` process is only an API
+# client.  Killing it -- even with a process-group signal -- does NOT kill
+# the exec'd process inside the container; that process lives in the
+# container's PID namespace and dies only when the container is torn down.
+# The `hang` behavior therefore detaches an "inner writer" into its own
+# session (perl POSIX::setsid; macOS has no setsid(1)) which keeps appending
+# `inner-write` events after the client is gone, and fake `stop` is what
+# kills it -- recording `stop-writer-alive` first if it was still running,
+# which is the observable proof that a group signal alone did not stop it.
 set -u
 
 STATE="${FAKE_RUNTIME_STATE:?FAKE_RUNTIME_STATE must be set}"
@@ -39,8 +51,31 @@ case "$cmd" in
         exit 0
         ;;
     stop)
-        echo "stop" >> "$STATE/events"
+        # Tearing down the container kills every process in its PID
+        # namespace, including exec'd ones the client abandoned.  Record
+        # whether the inner writer was still alive when stop arrived, then
+        # kill it and wait until it is gone -- when real `stop` returns,
+        # nothing inside the container is running anymore.
+        if [ -f "$STATE/inner_writer_pid" ]; then
+            writer_pid=$(cat "$STATE/inner_writer_pid")
+            if kill -0 "$writer_pid" 2>/dev/null; then
+                echo "stop-writer-alive" >> "$STATE/events"
+                kill -9 "$writer_pid" 2>/dev/null
+                while kill -0 "$writer_pid" 2>/dev/null; do sleep 0.01; done
+            fi
+        fi
+        echo "stop $*" >> "$STATE/events"
         rm -f "$STATE/running"
+        exit 0
+        ;;
+    start)
+        echo "start $*" >> "$STATE/events"
+        case "${FAKE_START_BEHAVIOR:-succeed}" in
+            fail)
+                exit 1
+                ;;
+        esac
+        touch "$STATE/running"
         exit 0
         ;;
     rm)
@@ -107,6 +142,22 @@ case "$cmd" in
                         exit "${FAKE_PREPROCESS_BEHAVIOR#fail:}"
                         ;;
                     hang)
+                        # Spawn the container-side process as its own session
+                        # leader so group-delivered signals kill only this
+                        # client, then block like the real exec client does.
+                        # The writer appends `inner-write` events (a stand-in
+                        # for creating root-owned files in the bind mount)
+                        # until fake `stop` kills it; the loop is bounded so
+                        # a failed scenario cannot leak it for long.
+                        perl -MPOSIX -e 'POSIX::setsid(); exec @ARGV or die "exec failed: $!"' \
+                            bash -c '
+                                i=0
+                                while [ "$i" -lt 600 ]; do
+                                    echo "inner-write $i" >> "$FAKE_RUNTIME_STATE/events"
+                                    i=$((i + 1))
+                                    sleep 0.05
+                                done' &
+                        echo $! > "$STATE/inner_writer_pid"
                         sleep 120
                         exit 0
                         ;;

--- a/tests/decoupled/fake_bin/podman
+++ b/tests/decoupled/fake_bin/podman
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Podman alias for the fake container runtime used by the regression tests.
+exec "$(dirname "$0")/docker" "$@"

--- a/tests/decoupled/fake_bin/uv
+++ b/tests/decoupled/fake_bin/uv
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fake `uv` for the run_single_decoupled.sh regression tests.  Answers the
+# runner's host-side python probes without needing a real environment; the
+# probes are recognized by distinctive substrings of their inline code.
+set -u
+
+case "$*" in
+    *podman_or_docker*)
+        echo "docker"
+        ;;
+    *instance_prefix*)
+        echo ""
+        ;;
+    *socket.socket*)
+        echo "18999"
+        ;;
+    *)
+        # Anything else (bundle validation, artifact guard, ...) is beyond
+        # the failure paths under test; succeed quietly.
+        exit 0
+        ;;
+esac

--- a/tests/decoupled/test_ownership_restore.sh
+++ b/tests/decoupled/test_ownership_restore.sh
@@ -15,7 +15,9 @@
 # The container runtime (docker/podman) and the host-side `uv` probes are
 # replaced with fakes from tests/decoupled/fake_bin; no real containers are
 # involved.  The fakes record the commands the runner issues, and the tests
-# assert on that recorded event sequence plus the runner's exit code.  See
+# assert on that recorded event sequence plus the runner's exit code -- and,
+# for orderings the events file cannot see (execs it does not record, like
+# the bundle rm), on the complete calls.log invocation order.  See
 # fake_bin/docker for the client/container signal-semantics model.
 #
 # Corner-case -> coverage map:
@@ -35,11 +37,15 @@
 #           (quiesce-before-restore); `start` sits between them; the last
 #           `inner-write` precedes the cleanup chown (the race is closed)
 #   C5 run_parallel.py escalates SIGTERM to SIGKILL after only 3 seconds
-#        -> s4/s5: the pending path's FIRST container action is `stop`
-#           with `-t 0` (no 10s grace for a `sleep` PID 1 that cannot
-#           receive it; an accepted stop completes daemon-side even if the
-#           client is later SIGKILLed).  The SIGKILL truncation itself is
-#           not directly testable (a SIGKILLed bash leaves no state to
+#        -> s4/s5: cleanup's FIRST container operation of ANY kind is the
+#           quiesce `stop -t 0` -- ahead even of the bundle `exec rm`,
+#           which needs the client to survive the round-trip and could
+#           spend the whole window (no 10s grace for a `sleep` PID 1 that
+#           cannot receive it; an accepted stop completes daemon-side even
+#           if the client is later SIGKILLed).  The events file does not
+#           record the bundle rm, so this ordering is asserted from the
+#           complete calls.log.  The SIGKILL truncation itself is not
+#           directly testable (a SIGKILLed bash leaves no state to
 #           assert), so the mitigation is structural: ordering + timeout
 #           are asserted here, and the next-run self-heal is C8.
 #   C6 container restart fails after the quiesce stop
@@ -54,6 +60,14 @@
 #           <owner> /workspace/dumps` (argument shape asserted in s1), so
 #           the next successful run of the same output folder self-heals
 #           anything a killed cleanup left behind
+#   C9 the quiesce stop FAILS while the container keeps running.  `start`
+#      on an already-running container returns 0 (real-Docker semantics,
+#      observed in review on 29.6.2), so it cannot stand in as a
+#      stopped-state check
+#        -> s8: a failed first stop gates the whole restoration -- no
+#           `start`, no chown against the live writer, warning only --
+#           and the teardown stop (the fake fails only the first) still
+#           kills the writer; the stranded files are C8's self-heal
 #   Out of scope (documented follow-up, per review agreement): root-owned
 #   files written after the restoration point by task `process_command`
 #   background services or by the eval phase; both are the same family
@@ -160,7 +174,8 @@ run_runner() {
 }
 
 start_runner_own_pgroup() {
-    # $1 (optional) container-start behavior for the fake runtime.
+    # $1 (optional) container-start behavior, $2 (optional) container-stop
+    # behavior for the fake runtime.
     # Launch the runner as its own process-group leader so a signal can be
     # delivered to the whole group, mirroring Ctrl-C / an orchestrator kill.
     # A non-job-control shell starts async children with SIGINT/SIGQUIT
@@ -174,6 +189,7 @@ start_runner_own_pgroup() {
         FAKE_PREPROCESS_BEHAVIOR="hang" \
         FAKE_CHOWN_BEHAVIOR="succeed" \
         FAKE_START_BEHAVIOR="${1:-succeed}" \
+        FAKE_STOP_BEHAVIOR="${2:-succeed}" \
         FAKE_DUMPS_OWNER="1000:1000" \
         perl -e '$SIG{INT} = "DEFAULT"; $SIG{QUIT} = "DEFAULT"; setpgrp(0, 0); exec @ARGV; die "exec failed: $!"' \
         "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1 &
@@ -277,6 +293,43 @@ assert_last_event_order() {
     fi
 }
 
+assert_call_before_last() {
+    # $1 label, $2 fixed string whose FIRST calls.log occurrence must
+    # precede the LAST occurrence of fixed string $3.  calls.log sees every
+    # runtime invocation, including execs the events file never records
+    # (C5: cleanup's bundle rm); last-occurrence matching sidesteps the
+    # fake mktemp always returning the same bundle path, so earlier
+    # main-flow rms of that path cannot satisfy the assertion.
+    local first last
+    first=$(grep -nF -- "$2" "$STATE/calls.log" 2>/dev/null |
+        head -n 1 | cut -d: -f1)
+    last=$(grep -nF -- "$3" "$STATE/calls.log" 2>/dev/null |
+        tail -n 1 | cut -d: -f1)
+    if [ -n "$first" ] && [ -n "$last" ] && [ "$first" -lt "$last" ]; then
+        pass "$1"
+    else
+        fail "$1 (calls.log lines: first '$2'=${first:-absent}, last '$3'=${last:-absent}; see $SCENARIO_DIR)"
+    fi
+}
+
+assert_cleanup_opens_with_stop() {
+    # $1 label.  In the interrupted scenarios the hung preprocess exec is
+    # the last main-flow runtime invocation, so the very next call in
+    # calls.log is cleanup's first container operation.  Per C5 it must be
+    # the quiesce `stop -t 0`: not the bundle rm, not any other exec --
+    # nothing that needs a live client may spend the SIGKILL window before
+    # the stop has been submitted.
+    local pre next
+    pre=$(grep -n "container_preprocess" "$STATE/calls.log" 2>/dev/null |
+        tail -n 1 | cut -d: -f1)
+    next=""
+    [ -n "$pre" ] && next=$(sed -n "$((pre + 1))p" "$STATE/calls.log")
+    case "$next" in
+        *" stop -t 0 "*) pass "$1" ;;
+        *) fail "$1 (call after preprocess: '${next:-absent}'; see $SCENARIO_DIR)" ;;
+    esac
+}
+
 # ---------------------------------------------------------------------------
 # C1: preprocess fails but its exec client RETURNS, so the container-side
 # process is already gone -- the main flow restores ownership directly and
@@ -374,6 +427,11 @@ signal_scenario() {
         "SIG$sig: writer survives the signal; quiesce precedes restoration" \
         "preprocess-start" "inner-write" "stop-writer-alive" "stop -t 0" \
         "start" "chown -R -- 1000:1000 /workspace/dumps" "stop"
+    assert_call_before_last \
+        "SIG$sig: the quiesce stop is submitted before cleanup's bundle rm" \
+        "stop -t 0" "rm -f -- /run/fake-decoupled-bundle.json"
+    assert_cleanup_opens_with_stop \
+        "SIG$sig: cleanup's first container operation is the quiesce stop"
     assert_last_event_order \
         "SIG$sig: nothing is written after the restoration" \
         "inner-write" "chown -R -- "
@@ -425,6 +483,11 @@ else
         "143" "$s6_exit"
     assert_event_subsequence "s6: quiesce still happens before the failed restart" \
         "stop-writer-alive" "stop -t 0" "start"
+    assert_call_before_last \
+        "s6: the quiesce stop is submitted before cleanup's bundle rm" \
+        "stop -t 0" "rm -f -- /run/fake-decoupled-bundle.json"
+    assert_cleanup_opens_with_stop \
+        "s6: cleanup's first container operation is the quiesce stop"
     assert_no_event "s6: no restoration without a running container" \
         "chown -R -- "
     assert_log_contains "s6: the failure is reported as a warning" \
@@ -452,6 +515,60 @@ assert_eq "s7: exactly one restoration (the main-flow hand-off)" \
 assert_no_event "s7: cleanup's pending path is not entered" "start"
 assert_event_order "s7: hand-off precedes the final stop" \
     "chown -R -- " "stop"
+
+# ---------------------------------------------------------------------------
+# C9: the quiescing stop itself FAILS while the writer keeps running.  Real
+# `docker start` returns 0 on an already-running container, so the failed
+# stop is the runner's only signal -- it must gate the whole restoration:
+# no restart, no chown into a live writer, warning only.  The fake fails
+# just the first stop, so the teardown stop still kills the writer
+# (`stop-writer-alive` at the SECOND stop proves it was alive the whole
+# time chown could have run) and the container still comes down.
+note "scenario 8: failed quiesce stop skips restoration, writer never chowned"
+new_workdir
+start_runner_own_pgroup succeed fail-once
+if ! wait_for_file "$STATE/preprocess_started" 300; then
+    fail "s8: runner never reached preprocess (see $SCENARIO_DIR)"
+    kill -KILL -- "-$RUNNER_PID" 2>/dev/null
+    wait "$RUNNER_PID" 2>/dev/null
+else
+    sleep 0.5
+    kill -TERM -- "-$RUNNER_PID" 2>/dev/null
+    ( sleep 15 && kill -KILL -- "-$RUNNER_PID" ) >/dev/null 2>&1 &
+    s8_watchdog=$!
+    wait "$RUNNER_PID" 2>/dev/null
+    s8_exit=$?
+    kill "$s8_watchdog" 2>/dev/null
+    wait "$s8_watchdog" 2>/dev/null
+    assert_eq "s8: interruption exit code survives the failed stop" \
+        "143" "$s8_exit"
+    assert_no_event "s8: no chown while the writer may still be running" \
+        "chown -R -- "
+    assert_no_event "s8: no restart after a failed quiesce stop" "start"
+    assert_eq "s8: exactly one stop failure (the quiesce attempt)" \
+        "1" "$(count_events "stop-fail")"
+    assert_event_subsequence \
+        "s8: the writer outlives the failed stop, dies at the teardown stop" \
+        "preprocess-start" "inner-write" "stop-fail" "stop-writer-alive" \
+        "stop -t 0"
+    assert_log_contains "s8: the skipped restoration is reported as a warning" \
+        "Warning: could not restore output ownership"
+    assert_call_before_last \
+        "s8: the quiesce stop is submitted before cleanup's bundle rm" \
+        "stop -t 0" "rm -f -- /run/fake-decoupled-bundle.json"
+    assert_cleanup_opens_with_stop \
+        "s8: cleanup's first container operation is the quiesce stop"
+    if [ ! -e "$STATE/running" ]; then
+        pass "s8: container was stopped by the teardown retry"
+    else
+        fail "s8: container still running after cleanup (see $SCENARIO_DIR)"
+    fi
+    if [ ! -e "$STATE/created" ]; then
+        pass "s8: container was removed"
+    else
+        fail "s8: container still present after cleanup (see $SCENARIO_DIR)"
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/decoupled/test_ownership_restore.sh
+++ b/tests/decoupled/test_ownership_restore.sh
@@ -7,14 +7,58 @@
 # pre-preprocess owner:
 #   1. even when preprocess fails,
 #   2. without clobbering the preprocess exit code,
-#   3. through a best-effort retry in cleanup() before the container is
-#      stopped, which also covers SIGINT/SIGTERM interruptions.
+#   3. through a best-effort pass in cleanup() that first QUIESCES any
+#      container-side writer (killing the local `docker exec` client does
+#      not kill the exec'd process inside the container), then restarts the
+#      inert container and restores ownership -- covering SIGINT/SIGTERM.
 #
 # The container runtime (docker/podman) and the host-side `uv` probes are
 # replaced with fakes from tests/decoupled/fake_bin; no real containers are
 # involved.  The fakes record the commands the runner issues, and the tests
-# assert on that recorded sequence (preprocess -> chown -> stop) plus the
-# runner's exit code.
+# assert on that recorded event sequence plus the runner's exit code.  See
+# fake_bin/docker for the client/container signal-semantics model.
+#
+# Corner-case -> coverage map:
+#   C1 preprocess fails, exec client returns normally
+#        -> s1 (restored via the main flow; cleanup's pending path must NOT
+#           re-enter: no `start` event)
+#   C2 restoration fails after a failed preprocess
+#        -> s2 (warning only; preprocess exit code preserved; cleanup
+#           retries through the quiesced stop -> start -> chown path)
+#   C3 restoration fails after a successful preprocess
+#        -> s3 (fatal: the host agent may not run on root-owned output)
+#   C4 group-delivered SIGTERM/SIGINT kills the exec client while the
+#      container-side process keeps writing (the reviewer's race; produced
+#      in production by run_parallel.py's killpg on task timeout)
+#        -> s4/s5: `stop-writer-alive` proves the writer survived the
+#           group signal; first `stop` precedes the cleanup chown
+#           (quiesce-before-restore); `start` sits between them; the last
+#           `inner-write` precedes the cleanup chown (the race is closed)
+#   C5 run_parallel.py escalates SIGTERM to SIGKILL after only 3 seconds
+#        -> s4/s5: the pending path's FIRST container action is `stop`
+#           with `-t 0` (no 10s grace for a `sleep` PID 1 that cannot
+#           receive it; an accepted stop completes daemon-side even if the
+#           client is later SIGKILLed).  The SIGKILL truncation itself is
+#           not directly testable (a SIGKILLed bash leaves no state to
+#           assert), so the mitigation is structural: ordering + timeout
+#           are asserted here, and the next-run self-heal is C8.
+#   C6 container restart fails after the quiesce stop
+#        -> s6 (warning only; container still stopped and removed; the
+#           interruption exit code is preserved)
+#   C7 successful hand-off (the healthy path)
+#        -> s7 (exactly one chown -- the main-flow hand-off -- and the
+#           pending path is never entered: no `start` event)
+#   C8 SIGKILL / double-Ctrl-C strands root-owned files with no cleanup
+#        -> not directly testable (no process left to observe); bounded by
+#           design: the restoration is always a full-tree `chown -R
+#           <owner> /workspace/dumps` (argument shape asserted in s1), so
+#           the next successful run of the same output folder self-heals
+#           anything a killed cleanup left behind
+#   Out of scope (documented follow-up, per review agreement): root-owned
+#   files written after the restoration point by task `process_command`
+#   background services or by the eval phase; both are the same family
+#   ("container-side root writers that outlive the hand-off") and need a
+#   separate end-of-run restoration pass.
 #
 # Requirements: Linux or any GNU userland (the runner itself depends on GNU
 # `readlink -f` semantics).  Run from anywhere:
@@ -46,6 +90,14 @@ note() {
 }
 
 on_exit() {
+    # A failed scenario may leave a detached inner writer running (it is
+    # normally killed by the fake `stop`); reap it so nothing outlives the
+    # test run.
+    for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
+        if [ -f "$dir/state/inner_writer_pid" ]; then
+            kill -9 "$(cat "$dir/state/inner_writer_pid")" 2>/dev/null
+        fi
+    done
     if [ "$FAIL_COUNT" -eq 0 ] && [ "${KEEP_TEST_ARTIFACTS:-0}" != "1" ]; then
         for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
             rm -rf -- "$dir"
@@ -108,6 +160,7 @@ run_runner() {
 }
 
 start_runner_own_pgroup() {
+    # $1 (optional) container-start behavior for the fake runtime.
     # Launch the runner as its own process-group leader so a signal can be
     # delivered to the whole group, mirroring Ctrl-C / an orchestrator kill.
     # A non-job-control shell starts async children with SIGINT/SIGQUIT
@@ -120,6 +173,7 @@ start_runner_own_pgroup() {
         FAKE_RUNTIME_STATE="$STATE" \
         FAKE_PREPROCESS_BEHAVIOR="hang" \
         FAKE_CHOWN_BEHAVIOR="succeed" \
+        FAKE_START_BEHAVIOR="${1:-succeed}" \
         FAKE_DUMPS_OWNER="1000:1000" \
         perl -e '$SIG{INT} = "DEFAULT"; $SIG{QUIT} = "DEFAULT"; setpgrp(0, 0); exec @ARGV; die "exec failed: $!"' \
         "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1 &
@@ -149,6 +203,36 @@ event_last_lineno() {
 
 count_events() {
     grep -c "^$1" "$STATE/events" 2>/dev/null || true
+}
+
+assert_event_subsequence() {
+    # $1 label; remaining args are event prefixes that must appear in the
+    # events file in the given order (as a subsequence: other events may be
+    # interleaved).  Prefix matching is literal, no regex.
+    local label=$1; shift
+    local lineno=0 prefix next
+    for prefix in "$@"; do
+        next=$(awk -v start="$lineno" -v pat="$prefix" \
+            'NR > start && index($0, pat) == 1 {print NR; exit}' \
+            "$STATE/events" 2>/dev/null)
+        if [ -z "$next" ]; then
+            fail "$label (no '$prefix' after line $lineno; see $SCENARIO_DIR)"
+            return
+        fi
+        lineno=$next
+    done
+    pass "$label"
+}
+
+assert_no_event() {
+    # $1 label, $2 event prefix that must not appear
+    local n
+    n=$(count_events "$2")
+    if [ "${n:-0}" -eq 0 ]; then
+        pass "$1"
+    else
+        fail "$1 ('$2' appeared $n time(s); see $SCENARIO_DIR)"
+    fi
 }
 
 assert_eq() {
@@ -194,6 +278,12 @@ assert_last_event_order() {
 }
 
 # ---------------------------------------------------------------------------
+# C1: preprocess fails but its exec client RETURNS, so the container-side
+# process is already gone -- the main flow restores ownership directly and
+# cleanup's pending path (quiesce + restart) must not re-enter.  The
+# full-tree `chown -R <owner> /workspace/dumps` argument shape asserted here
+# is also the C8 self-heal: it is what collects files stranded by an
+# unkillable-cleanup (SIGKILL) on the next successful run.
 note "scenario 1: preprocess failure still restores ownership"
 new_workdir
 run_runner "fail:7" "succeed" "4242:4242"
@@ -203,12 +293,17 @@ assert_event_order "s1: ownership restored after preprocess" \
     "preprocess-start" "chown -R -- "
 assert_event_order "s1: ownership restored before container stop" \
     "chown -R -- " "stop"
-assert_eq "s1: restoration uses the captured owner" \
+assert_eq "s1: restoration is a full-tree pass with the captured owner" \
     "1" "$(count_events "chown -R -- 4242:4242 /workspace/dumps")"
 assert_eq "s1: restoration is not repeated by cleanup" \
     "1" "$(count_events "chown -R -- ")"
+assert_no_event "s1: cleanup's pending path is not entered" "start"
 
 # ---------------------------------------------------------------------------
+# C2: the main-flow restoration itself fails after a failed preprocess.  The
+# preprocess exit code stays authoritative and cleanup retries -- through the
+# quiesced path (stop first, then restart, then chown), since after any
+# abnormal flow a container-side writer cannot be ruled out.
 note "scenario 2: failed restoration cannot mask the preprocess exit code"
 new_workdir
 run_runner "fail:7" "fail" "1000:1000"
@@ -217,10 +312,13 @@ assert_log_contains "s2: restoration failure is only a warning" \
     "Warning: could not restore output ownership after failed preprocess"
 assert_eq "s2: cleanup retries the pending restoration" \
     "2" "$(count_events "chown -R -- ")"
-assert_last_event_order "s2: the cleanup retry happens before container stop" \
-    "chown -R -- " "stop"
+assert_event_subsequence "s2: the cleanup retry goes through the quiesced path" \
+    "preprocess-start" "chown -R -- " "stop -t 0" "start" "chown -R -- " "stop"
 
 # ---------------------------------------------------------------------------
+# C3: restoration fails after a SUCCESSFUL preprocess -- fatal, because the
+# host agent must never run against root-owned output.  Cleanup still makes
+# its best-effort quiesced retry.
 note "scenario 3: successful preprocess still fails hard on a failed chown"
 new_workdir
 run_runner "succeed" "fail" "1000:1000"
@@ -230,18 +328,27 @@ assert_log_contains "s3: hand-off failure is reported" \
     "Failed to hand output ownership to the host agent"
 assert_eq "s3: cleanup still retries the pending restoration" \
     "2" "$(count_events "chown -R -- ")"
+assert_event_subsequence "s3: the cleanup retry is quiesced too" \
+    "chown -R -- " "stop -t 0" "start" "chown -R -- "
 
 # ---------------------------------------------------------------------------
-# Interruption coverage.  A group-delivered fatal signal kills the hung
-# preprocess exec and makes the runner abort through its EXIT trap, so the
-# restoration must come from cleanup()'s pending path — for SIGTERM and
-# SIGINT alike.  Each scenario asserts the signal's conventional 128+N exit
-# code (a 137 here means the watchdog had to SIGKILL a runner that ignored
-# the signal), and that ownership is restored exactly once, before the
-# container is stopped.
+# C4 + C5 (s4 SIGTERM / s5 SIGINT).  A group-delivered fatal signal kills
+# the local exec CLIENT, but the container-side process survives it and
+# keeps writing (`inner-write` events) until the container is torn down —
+# the exact race observed in review on rootful Docker, and what
+# run_parallel.py's killpg produces on task timeout.  Cleanup must
+# therefore quiesce first: its pending path's FIRST container action is
+# `stop -t 0` (C5: only a ~3s window exists before the orchestrator's
+# SIGKILL; a `sleep` PID 1 never honors a graceful stop, so any longer
+# timeout is pure loss), then restart the inert container, then chown.
+# `stop-writer-alive` proves the writer outlived the group signal, and the
+# last `inner-write` preceding the restoration proves the race is closed.
+# Each scenario also asserts the signal's conventional 128+N exit code (a
+# 137 here means the watchdog had to SIGKILL a runner that ignored the
+# signal).
 signal_scenario() {
     local sig=$1 expected_exit=$2
-    note "scenario SIG$sig: interruption still restores ownership"
+    note "scenario SIG$sig: interruption quiesces the writer, then restores"
     new_workdir
     start_runner_own_pgroup
     if ! wait_for_file "$STATE/preprocess_started" 300; then
@@ -263,21 +370,88 @@ signal_scenario() {
     wait "$watchdog" 2>/dev/null
     assert_eq "SIG$sig: runner exits with the signal's status" \
         "$expected_exit" "$observed_exit"
-    assert_event_order "SIG$sig: ownership restored after interruption" \
-        "preprocess-start" "chown -R -- "
-    assert_event_order "SIG$sig: restoration happens before container stop" \
-        "chown -R -- " "stop"
+    assert_event_subsequence \
+        "SIG$sig: writer survives the signal; quiesce precedes restoration" \
+        "preprocess-start" "inner-write" "stop-writer-alive" "stop -t 0" \
+        "start" "chown -R -- 1000:1000 /workspace/dumps" "stop"
+    assert_last_event_order \
+        "SIG$sig: nothing is written after the restoration" \
+        "inner-write" "chown -R -- "
     assert_eq "SIG$sig: exactly one restoration attempt" \
         "1" "$(count_events "chown -R -- ")"
+    assert_eq "SIG$sig: the writer is dead by the second (final) stop" \
+        "1" "$(count_events "stop-writer-alive")"
+    assert_eq "SIG$sig: the container is restarted exactly once" \
+        "1" "$(count_events "start")"
     if [ ! -e "$STATE/running" ]; then
         pass "SIG$sig: container was stopped by cleanup"
     else
         fail "SIG$sig: container still running after cleanup (see $SCENARIO_DIR)"
     fi
+    if [ ! -e "$STATE/created" ]; then
+        pass "SIG$sig: container was removed by cleanup"
+    else
+        fail "SIG$sig: container still present after cleanup (see $SCENARIO_DIR)"
+    fi
 }
 
 signal_scenario TERM 143
 signal_scenario INT 130
+
+# ---------------------------------------------------------------------------
+# C6: the restart after the quiesce stop fails.  Restoration is best-effort
+# on this path — the runner must warn, keep the interruption exit code, and
+# still stop/remove the container.  No chown can happen (the container
+# never came back), so the stranded files are left for the next successful
+# run's full-tree hand-off (C8) — but the writer is still dead, which is
+# the part that must never fail.
+note "scenario 6: failed restart degrades to a warning, writer still dead"
+new_workdir
+start_runner_own_pgroup fail
+if ! wait_for_file "$STATE/preprocess_started" 300; then
+    fail "s6: runner never reached preprocess (see $SCENARIO_DIR)"
+    kill -KILL -- "-$RUNNER_PID" 2>/dev/null
+    wait "$RUNNER_PID" 2>/dev/null
+else
+    sleep 0.5
+    kill -TERM -- "-$RUNNER_PID" 2>/dev/null
+    ( sleep 15 && kill -KILL -- "-$RUNNER_PID" ) >/dev/null 2>&1 &
+    s6_watchdog=$!
+    wait "$RUNNER_PID" 2>/dev/null
+    s6_exit=$?
+    kill "$s6_watchdog" 2>/dev/null
+    wait "$s6_watchdog" 2>/dev/null
+    assert_eq "s6: interruption exit code survives the failed restart" \
+        "143" "$s6_exit"
+    assert_event_subsequence "s6: quiesce still happens before the failed restart" \
+        "stop-writer-alive" "stop -t 0" "start"
+    assert_no_event "s6: no restoration without a running container" \
+        "chown -R -- "
+    assert_log_contains "s6: the failure is reported as a warning" \
+        "Warning: could not restore output ownership"
+    if [ ! -e "$STATE/created" ]; then
+        pass "s6: container was still removed"
+    else
+        fail "s6: container still present after cleanup (see $SCENARIO_DIR)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# C7: successful hand-off.  The main flow restores ownership exactly once
+# and clears the pending flag, so cleanup's quiesce/restart path must never
+# run — the fix may not tax the healthy path.  The fake `docker cp` does
+# not materialize the bundle file, so the runner exits at the `chmod 600`
+# guard right AFTER the hand-off — the exact moment cleanup's non-pending
+# behavior is observable, without mocking the whole agent/eval pipeline.
+note "scenario 7: successful hand-off never re-enters the pending path"
+new_workdir
+run_runner "succeed" "succeed" "1000:1000"
+assert_log_contains "s7: the hand-off path completed" "Preprocess completed"
+assert_eq "s7: exactly one restoration (the main-flow hand-off)" \
+    "1" "$(count_events "chown -R -- ")"
+assert_no_event "s7: cleanup's pending path is not entered" "start"
+assert_event_order "s7: hand-off precedes the final stop" \
+    "chown -R -- " "stop"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/decoupled/test_ownership_restore.sh
+++ b/tests/decoupled/test_ownership_restore.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Regression tests for the ownership-restoration flow in
+# scripts/run_single_decoupled.sh.
+#
+# Preprocess runs as container root and writes into the bind-mounted output
+# tree (/workspace/dumps).  The runner must hand ownership back to the
+# pre-preprocess owner:
+#   1. even when preprocess fails,
+#   2. without clobbering the preprocess exit code,
+#   3. through a best-effort retry in cleanup() before the container is
+#      stopped, which also covers SIGINT/SIGTERM interruptions.
+#
+# The container runtime (docker/podman) and the host-side `uv` probes are
+# replaced with fakes from tests/decoupled/fake_bin; no real containers are
+# involved.  The fakes record the commands the runner issues, and the tests
+# assert on that recorded sequence (preprocess -> chown -> stop) plus the
+# runner's exit code.
+#
+# Requirements: Linux or any GNU userland (the runner itself depends on GNU
+# `readlink -f` semantics).  Run from anywhere:
+#   bash tests/decoupled/test_ownership_restore.sh
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/../.." && pwd)"
+RUNNER="$REPO_ROOT/scripts/run_single_decoupled.sh"
+FAKE_BIN="$TESTS_DIR/fake_bin"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+KEEP_DIRS=()
+
+pass() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "ok - $1"
+}
+
+fail() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "not ok - $1"
+}
+
+note() {
+    echo "# $*"
+}
+
+on_exit() {
+    if [ "$FAIL_COUNT" -eq 0 ] && [ "${KEEP_TEST_ARTIFACTS:-0}" != "1" ]; then
+        for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
+            rm -rf -- "$dir"
+        done
+    else
+        for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
+            note "artifacts kept in $dir"
+        done
+    fi
+}
+trap on_exit EXIT
+
+if [ ! -f "$RUNNER" ]; then
+    echo "runner not found: $RUNNER" >&2
+    exit 1
+fi
+
+# Any real task directory satisfies the runner's existence check; the fake
+# runtime never copies it anywhere.
+TASK_DIR_REL=$(
+    cd "$REPO_ROOT/tasks" 2>/dev/null &&
+    find . -mindepth 2 -maxdepth 2 -type d |
+    sed 's|^\./||' |
+    grep -E '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$' |
+    LC_ALL=C sort |
+    head -n 1
+)
+if [ -z "$TASK_DIR_REL" ]; then
+    echo "no task directory found under $REPO_ROOT/tasks" >&2
+    exit 1
+fi
+note "using task directory: $TASK_DIR_REL"
+
+new_workdir() {
+    SCENARIO_DIR=$(mktemp -d "${TMPDIR:-/tmp}/toolathlon-ownership-test.XXXXXX")
+    KEEP_DIRS+=("$SCENARIO_DIR")
+    STATE="$SCENARIO_DIR/state"
+    DUMPS="$SCENARIO_DIR/dumps"
+    mkdir -p "$STATE" "$DUMPS"
+}
+
+build_runner_cmd() {
+    # Positional gateway_port avoids the runner's live-socket probe.
+    RUNNER_CMD=(
+        bash "$RUNNER" "$TASK_DIR_REL" normal "$DUMPS" fake-model unified 5
+        scripts/formal_run_v0.json fake-image toolathlon_default 18999
+    )
+}
+
+run_runner() {
+    # $1 preprocess behavior, $2 chown behavior, $3 reported dumps owner
+    build_runner_cmd
+    env PATH="$FAKE_BIN:$PATH" \
+        FAKE_RUNTIME_STATE="$STATE" \
+        FAKE_PREPROCESS_BEHAVIOR="$1" \
+        FAKE_CHOWN_BEHAVIOR="$2" \
+        FAKE_DUMPS_OWNER="$3" \
+        "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1
+    RUNNER_EXIT=$?
+}
+
+start_runner_own_pgroup() {
+    # Launch the runner as its own process-group leader so a signal can be
+    # delivered to the whole group, mirroring Ctrl-C / an orchestrator kill.
+    # A non-job-control shell starts async children with SIGINT/SIGQUIT
+    # ignored, the ignore survives both exec and setsid, and an ignored
+    # signal would make kill -INT a silent no-op (the scenario would then
+    # pass vacuously once the fake's hang expires).  The perl wrapper
+    # restores the default dispositions before entering the new group.
+    build_runner_cmd
+    env PATH="$FAKE_BIN:$PATH" \
+        FAKE_RUNTIME_STATE="$STATE" \
+        FAKE_PREPROCESS_BEHAVIOR="hang" \
+        FAKE_CHOWN_BEHAVIOR="succeed" \
+        FAKE_DUMPS_OWNER="1000:1000" \
+        perl -e '$SIG{INT} = "DEFAULT"; $SIG{QUIT} = "DEFAULT"; setpgrp(0, 0); exec @ARGV; die "exec failed: $!"' \
+        "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1 &
+    RUNNER_PID=$!
+}
+
+wait_for_file() {
+    # $1 path, $2 max iterations of 0.2s
+    local i=0
+    while [ "$i" -lt "$2" ]; do
+        [ -e "$1" ] && return 0
+        sleep 0.2
+        i=$((i + 1))
+    done
+    return 1
+}
+
+event_lineno() {
+    # First line number in the events file matching prefix $1; empty if none.
+    grep -n "^$1" "$STATE/events" 2>/dev/null | head -n 1 | cut -d: -f1
+}
+
+event_last_lineno() {
+    # Last line number in the events file matching prefix $1; empty if none.
+    grep -n "^$1" "$STATE/events" 2>/dev/null | tail -n 1 | cut -d: -f1
+}
+
+count_events() {
+    grep -c "^$1" "$STATE/events" 2>/dev/null || true
+}
+
+assert_eq() {
+    # $1 label, $2 expected, $3 actual
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1 (expected '$2', got '$3'; see $SCENARIO_DIR)"
+    fi
+}
+
+assert_log_contains() {
+    # $1 label, $2 fixed string expected in runner.log
+    if grep -qF "$2" "$STATE/runner.log"; then
+        pass "$1"
+    else
+        fail "$1 (missing '$2' in $STATE/runner.log)"
+    fi
+}
+
+assert_event_order() {
+    # $1 label, $2 earlier event prefix, $3 later event prefix
+    local earlier later
+    earlier=$(event_lineno "$2")
+    later=$(event_lineno "$3")
+    if [ -n "$earlier" ] && [ -n "$later" ] && [ "$earlier" -lt "$later" ]; then
+        pass "$1"
+    else
+        fail "$1 (lines: '$2'=${earlier:-absent}, '$3'=${later:-absent}; see $SCENARIO_DIR)"
+    fi
+}
+
+assert_last_event_order() {
+    # Like assert_event_order, but pins the LAST occurrence of $2 before $3.
+    local earlier later
+    earlier=$(event_last_lineno "$2")
+    later=$(event_lineno "$3")
+    if [ -n "$earlier" ] && [ -n "$later" ] && [ "$earlier" -lt "$later" ]; then
+        pass "$1"
+    else
+        fail "$1 (lines: last '$2'=${earlier:-absent}, '$3'=${later:-absent}; see $SCENARIO_DIR)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+note "scenario 1: preprocess failure still restores ownership"
+new_workdir
+run_runner "fail:7" "succeed" "4242:4242"
+assert_eq "s1: preprocess exit code is preserved" "7" "$RUNNER_EXIT"
+assert_log_contains "s1: failure is reported" "Preprocess failed, exit code: 7"
+assert_event_order "s1: ownership restored after preprocess" \
+    "preprocess-start" "chown -R -- "
+assert_event_order "s1: ownership restored before container stop" \
+    "chown -R -- " "stop"
+assert_eq "s1: restoration uses the captured owner" \
+    "1" "$(count_events "chown -R -- 4242:4242 /workspace/dumps")"
+assert_eq "s1: restoration is not repeated by cleanup" \
+    "1" "$(count_events "chown -R -- ")"
+
+# ---------------------------------------------------------------------------
+note "scenario 2: failed restoration cannot mask the preprocess exit code"
+new_workdir
+run_runner "fail:7" "fail" "1000:1000"
+assert_eq "s2: preprocess exit code survives a failed chown" "7" "$RUNNER_EXIT"
+assert_log_contains "s2: restoration failure is only a warning" \
+    "Warning: could not restore output ownership after failed preprocess"
+assert_eq "s2: cleanup retries the pending restoration" \
+    "2" "$(count_events "chown -R -- ")"
+assert_last_event_order "s2: the cleanup retry happens before container stop" \
+    "chown -R -- " "stop"
+
+# ---------------------------------------------------------------------------
+note "scenario 3: successful preprocess still fails hard on a failed chown"
+new_workdir
+run_runner "succeed" "fail" "1000:1000"
+assert_eq "s3: failed hand-off after successful preprocess is fatal" \
+    "1" "$RUNNER_EXIT"
+assert_log_contains "s3: hand-off failure is reported" \
+    "Failed to hand output ownership to the host agent"
+assert_eq "s3: cleanup still retries the pending restoration" \
+    "2" "$(count_events "chown -R -- ")"
+
+# ---------------------------------------------------------------------------
+# Interruption coverage.  A group-delivered fatal signal kills the hung
+# preprocess exec and makes the runner abort through its EXIT trap, so the
+# restoration must come from cleanup()'s pending path — for SIGTERM and
+# SIGINT alike.  Each scenario asserts the signal's conventional 128+N exit
+# code (a 137 here means the watchdog had to SIGKILL a runner that ignored
+# the signal), and that ownership is restored exactly once, before the
+# container is stopped.
+signal_scenario() {
+    local sig=$1 expected_exit=$2
+    note "scenario SIG$sig: interruption still restores ownership"
+    new_workdir
+    start_runner_own_pgroup
+    if ! wait_for_file "$STATE/preprocess_started" 300; then
+        fail "SIG$sig: runner never reached preprocess (see $SCENARIO_DIR)"
+        kill -KILL -- "-$RUNNER_PID" 2>/dev/null
+        wait "$RUNNER_PID" 2>/dev/null
+        return
+    fi
+    sleep 0.5  # let the runner block inside the hung preprocess exec
+    kill "-$sig" -- "-$RUNNER_PID" 2>/dev/null
+    # Bound the wait: if the signal were ever ignored again, the watchdog
+    # SIGKILLs the group, wait returns 137, and the exit-code assertion
+    # fails fast instead of riding out the fake's hang.
+    ( sleep 15 && kill -KILL -- "-$RUNNER_PID" ) >/dev/null 2>&1 &
+    local watchdog=$!
+    wait "$RUNNER_PID" 2>/dev/null
+    local observed_exit=$?
+    kill "$watchdog" 2>/dev/null
+    wait "$watchdog" 2>/dev/null
+    assert_eq "SIG$sig: runner exits with the signal's status" \
+        "$expected_exit" "$observed_exit"
+    assert_event_order "SIG$sig: ownership restored after interruption" \
+        "preprocess-start" "chown -R -- "
+    assert_event_order "SIG$sig: restoration happens before container stop" \
+        "chown -R -- " "stop"
+    assert_eq "SIG$sig: exactly one restoration attempt" \
+        "1" "$(count_events "chown -R -- ")"
+    if [ ! -e "$STATE/running" ]; then
+        pass "SIG$sig: container was stopped by cleanup"
+    else
+        fail "SIG$sig: container still running after cleanup (see $SCENARIO_DIR)"
+    fi
+}
+
+signal_scenario TERM 143
+signal_scenario INT 130
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "passed: $PASS_COUNT, failed: $FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes a `PermissionError` that prevents decoupled mode from completing for non-root Linux users running rootful container runtimes, and removes three model API-key exposure paths: process arguments, echoed/captured logs, and the private-mode submission payload. Changes are split into focused commits; evaluation behavior is unchanged.

## Why

**Decoupled mode fails for non-root host users running a rootful Docker or Podman runtime on Linux.** Preprocess runs as root inside the task image and creates `status.json` in the bind-mounted output directory. The host agent loop then runs as the invoking user and dies with `PermissionError: [Errno 13]` before the first model request. This reproduces deterministically on a clean clone with rootful Docker on Linux. macOS Docker Desktop and default rootless Podman ownership mappings do not exhibit the original failure.

**The model API key leaks into places users routinely share.**

- Both runner scripts expand `TOOLATHLON_OPENAI_API_KEY` into the `docker run` argument list and echo the full start command, so the key lands in `ps` output, terminal scrollback, `tee`'d run logs, and CI logs — exactly the things people paste into bug reports.
- In private mode, `eval_client.py` sends the real key to the evaluation server even though the server never reads it for private jobs (`eval_server.py` declares the field `Optional`, sets `TOOLATHLON_OPENAI_API_KEY=dummy`, and proxies inference through the WebSocket client). Private mode exists so the key can stay local; today it doesn't.
- The detached private worker also receives the key as a literal in its `python -c` code string and forwards it to `simple_client_ws.py` via `--llm-api-key`, keeping it visible in both processes' argv for the lifetime of the run.

## Reproduction of the ownership failure

Reproduced on a clean checkout with a non-root Linux host user, rootful Docker, and `lockon0927/toolathlon-task-image:1016beta`.

After configuring the model environment variables documented in the README:

```bash
bash scripts/run_single_decoupled.sh \
  finalpool/find-alita-paper \
  quickstart \
  /tmp/toolathlon-decoupled-repro \
  anthropic/claude-sonnet-4.5 \
  unified \
  100 \
  scripts/formal_run_v0.json \
  lockon0927/toolathlon-task-image:1016beta \
  toolathlon_default
```

Without the ownership fix, container preprocess completes, but the host agent loop fails before its first model request:

```text
PermissionError: [Errno 13] Permission denied: '.../status.json'
```

The bind-mounted file is owned by container/host root:

```bash
stat -c '%u:%g %a %n' \
  /tmp/toolathlon-decoupled-repro/finalpool/find-alita-paper/status.json
```

With this PR, the output tree is restored to its pre-preprocess owner; the same run proceeds through the host agent loop and passes the official evaluator.

Default rootless Podman does not exhibit the original ownership failure because container root maps to the invoking host user. The fix preserves that behavior by restoring the owner observed inside the container before preprocess.

## What

| Commit | Change |
|---|---|
| `ca68855` | `run_single_decoupled.sh`: capture the owner of the bind-mounted dumps tree (as seen inside the container's user namespace) before preprocess and restore it afterwards — host-writable on rootful Docker/Podman and rootless Podman alike |
| `6dd23c0` | `run_single_containerized.sh`: pass `TOOLATHLON_OPENAI_*` to Docker/Podman by name (`-e NAME`), so the value comes from the runtime's own environment instead of argv |
| `db9166c` | `run_single_decoupled.sh`: same by-name passthrough |
| `64c2fe3` | `eval_client.py` / `simple_client_ws.py`: submit `api_key: null` in private mode; hand the key to the detached worker via its environment instead of `python -c` code and argv |
| `314408a` | Follow-up: `--llm-api-key` falls back to `TOOLATHLON_OPENAI_API_KEY`, then `OPENAI_API_KEY`, then an empty key so endpoints without authentication keep working; align the `--api-key` help text |

## Compatibility

- Public-mode submissions are byte-identical to before.
- Both documented ways of setting `TOOLATHLON_OPENAI_*` — exporting in the shell or uncommenting the export block at the top of the scripts — already export the variables, so the value seen inside the container is unchanged.
- `--llm-api-key` still works and takes precedence when given explicitly.
- Otherwise, the key falls back to `TOOLATHLON_OPENAI_API_KEY`, then `OPENAI_API_KEY`, then an empty key, preserving the pre-existing behavior for endpoints without authentication.
- No task, grader, model-request, or evaluation-result behavior is changed.

## Testing

- Clean clone, `finalpool/find-alita-paper` in decoupled mode: reproduces the `PermissionError` without the ownership fix and passes the official evaluator with it.
- Re-verified after the capture-and-restore amendment; `status.json` ends up owned by the invoking host user.
- Existing `scripts/decoupled/tests` pass.
- Shell syntax, Python compilation, and diff whitespace checks pass.
- Post-run scans across run logs and dumps show zero occurrences of the key.
- `--llm-api-key` fallback semantics verified for five combinations:
  - Explicit flag
  - `TOOLATHLON_OPENAI_API_KEY`
  - `OPENAI_API_KEY`
  - Both environment variables (`TOOLATHLON_OPENAI_API_KEY` wins)
  - Neither environment variable (empty key, matching the previous behavior for auth-less endpoints)