### PR TITLE
woocommerce evals: don't crash on unknown email charsets in Subject headers

### DIFF
--- a/tasks/finalpool/woocommerce-new-product/evaluation/check_remote_new_product.py
+++ b/tasks/finalpool/woocommerce-new-product/evaluation/check_remote_new_product.py
@@ -319,11 +319,19 @@ def check_email_sending(agent_workspace: str, wc_client: WooCommerceClient) -> T
                     # Get subject
                     subject = ""
                     if msg["Subject"]:
-                        subject_parts = decode_header(msg["Subject"])
-                        subject = "".join([
-                            part.decode(encoding or 'utf-8') if isinstance(part, bytes) else part
-                            for part, encoding in subject_parts
-                        ])
+                        decoded_parts = []
+                        for part, encoding in decode_header(msg["Subject"]):
+                            if isinstance(part, bytes):
+                                # decode_header can report charsets Python has no codec
+                                # for (e.g. 'unknown-8bit'); fall back instead of failing
+                                # the whole email check.
+                                try:
+                                    decoded_parts.append(part.decode(encoding or 'utf-8', errors='replace'))
+                                except LookupError:
+                                    decoded_parts.append(part.decode('utf-8', errors='replace'))
+                            else:
+                                decoded_parts.append(part)
+                        subject = "".join(decoded_parts)
 
                     subject_lower = subject.lower()
 

--- a/tasks/finalpool/woocommerce-product-recall/evaluation/check_remote_recall.py
+++ b/tasks/finalpool/woocommerce-product-recall/evaluation/check_remote_recall.py
@@ -606,11 +606,19 @@ def check_recall_email_sending(agent_workspace: str, wc_client: WooCommerceClien
             # Get the subject and content of the email
             subject = ""
             if msg["Subject"]:
-                subject_parts = decode_header(msg["Subject"])
-                subject = "".join([
-                    part.decode(encoding or 'utf-8') if isinstance(part, bytes) else part
-                    for part, encoding in subject_parts
-                ])
+                decoded_parts = []
+                for part, encoding in decode_header(msg["Subject"]):
+                    if isinstance(part, bytes):
+                        # decode_header can report charsets Python has no codec
+                        # for (e.g. 'unknown-8bit'); fall back instead of failing
+                        # the whole email check.
+                        try:
+                            decoded_parts.append(part.decode(encoding or 'utf-8', errors='replace'))
+                        except LookupError:
+                            decoded_parts.append(part.decode('utf-8', errors='replace'))
+                    else:
+                        decoded_parts.append(part)
+                subject = "".join(decoded_parts)
             
             # Check if it's a recall email
             recall_keywords = ['recall', 'safety', 'urgent notice', 'product alert', 'withdrawal']

--- a/tasks/finalpool/woocommerce-stock-alert/evaluation/evaluate_updated_stock_alert.py
+++ b/tasks/finalpool/woocommerce-stock-alert/evaluation/evaluate_updated_stock_alert.py
@@ -326,11 +326,19 @@ class StockAlertEvaluator:
                 # Get email subject
                 subject = ""
                 if msg["Subject"]:
-                    subject_parts = decode_header(msg["Subject"])
-                    subject = "".join([
-                        part.decode(encoding or 'utf-8') if isinstance(part, bytes) else part
-                        for part, encoding in subject_parts
-                    ])
+                    decoded_parts = []
+                    for part, encoding in decode_header(msg["Subject"]):
+                        if isinstance(part, bytes):
+                            # decode_header can report charsets Python has no codec
+                            # for (e.g. 'unknown-8bit'); fall back instead of failing
+                            # the whole email check.
+                            try:
+                                decoded_parts.append(part.decode(encoding or 'utf-8', errors='replace'))
+                            except LookupError:
+                                decoded_parts.append(part.decode('utf-8', errors='replace'))
+                        else:
+                            decoded_parts.append(part)
+                    subject = "".join(decoded_parts)
 
                 # Check if it's a stock alert email
                 stock_alert_keywords = ['stock alert', '[stock alert]', 'low stock', 'safety threshold']
@@ -364,11 +372,19 @@ class StockAlertEvaluator:
                 # Get subject
                 subject = ""
                 if msg["Subject"]:
-                    subject_parts = decode_header(msg["Subject"])
-                    subject = "".join([
-                        part.decode(encoding or 'utf-8') if isinstance(part, bytes) else part
-                        for part, encoding in subject_parts
-                    ])
+                    decoded_parts = []
+                    for part, encoding in decode_header(msg["Subject"]):
+                        if isinstance(part, bytes):
+                            # decode_header can report charsets Python has no codec
+                            # for (e.g. 'unknown-8bit'); fall back instead of failing
+                            # the whole email check.
+                            try:
+                                decoded_parts.append(part.decode(encoding or 'utf-8', errors='replace'))
+                            except LookupError:
+                                decoded_parts.append(part.decode('utf-8', errors='replace'))
+                        else:
+                            decoded_parts.append(part)
+                    subject = "".join(decoded_parts)
 
                 # Get body
                 body = ""


### PR DESCRIPTION
The `woocommerce-product-recall` verifier failed whole runs with:

```
Recall Emails: ❌ FAILED
  Details: Recall email check error: unknown encoding: unknown-8bit
```

`email.header.decode_header` can report charset labels that are RFC-legal but have no Python codec (e.g. `unknown-8bit`); calling `part.decode(encoding or 'utf-8')` on those raises `LookupError`, which fails the entire email check regardless of what the agent actually sent.

Body decoding was already hardened against exactly this (`_decode_email_part` falls back to utf-8 with `errors="replace"`); the Subject path wasn't.

This PR applies the same fallback to Subject decoding in `woocommerce-product-recall`, and to the identical pattern in `woocommerce-stock-alert` (two sites) and `woocommerce-new-product`.