### PR TITLE
k8s-redis-helm-upgrade: preload the chart 22.0.0 redis image

### DIFF
--- a/tasks/finalpool/k8s-redis-helm-upgrade/scripts/init_redis_helm.sh
+++ b/tasks/finalpool/k8s-redis-helm-upgrade/scripts/init_redis_helm.sh
@@ -465,8 +465,14 @@ start_operation() {
   # bitnami chart 19.0.0 default redis tag.  Keep in lockstep with
   # ``initial_version`` above when the chart version is bumped.
   REDIS_TAG="7.2.4-debian-12-r9"
+  # bitnami chart 22.0.0 (the task's upgrade target, see evaluation/main.py)
+  # defaults to this redis tag.  Bitnami purged ``bitnami/*`` tags from Docker
+  # Hub in its 2025 migration, so upgraded pods hit ErrImagePull unless the
+  # ``bitnamilegacy`` variant is preloaded the same way as the initial image.
+  UPGRADE_REDIS_TAG="8.2.0-debian-12-r0"
   BITNAMILEGACY_IMAGES=(
     "redis:${REDIS_TAG}"
+    "redis:${UPGRADE_REDIS_TAG}"
   )
   for _name_tag in "${BITNAMILEGACY_IMAGES[@]}"; do
     src="bitnami/${_name_tag}"


### PR DESCRIPTION
Bitnami removed its `bitnami/*` tags from Docker Hub in the 2025 catalog migration. The task's init script already bridges this for the **initial** chart (19.0.0) by retagging/preloading `bitnamilegacy/redis:7.2.4-debian-12-r9` — but the task asks the agent to upgrade to chart **22.0.0**, whose default image `docker.io/bitnami/redis:8.2.0-debian-12-r0` now 404s.

Observed in runs: pods sit in `ErrImagePull`/`ImagePullBackOff` for minutes after the upgrade, and the agent can only recover by independently discovering the `bitnamilegacy` namespace override — a Docker Hub trivia test, not part of the task's intent.

Fix: add the upgrade-target tag to `BITNAMILEGACY_IMAGES` so the existing retag / pull-once / preload path covers it (`bitnamilegacy/redis:8.2.0-debian-12-r0` is live on Docker Hub). Same best-effort semantics as the existing entry.