### PR TITLE
vlm-history-completer: add live source URLs to the groundtruth accept-lists

### DIFF
--- a/tasks/finalpool/vlm-history-completer/groundtruth_workspace/groundtruth.json
+++ b/tasks/finalpool/vlm-history-completer/groundtruth_workspace/groundtruth.json
@@ -66,7 +66,8 @@
         "Model": "LAION CLIP",
         "Architecture": "Dual-Encoder",
         "Sources": [
-            "https://laion.ai/blog/large-openclip/"
+            "https://laion.ai/blog/large-openclip/",
+            "https://github.com/mlfoundations/open_clip"
         ]
     },
     {
@@ -75,6 +76,7 @@
         "Sources": [
             "https://github.com/CompVis/stable-diffusion",
             "https://github.com/runwayml/stable-diffusion",
+            "https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5",
             "https://github.com/Kameronski/stable-diffusion-1.5"
         ]
     },
@@ -119,7 +121,8 @@
         "Architecture": "LLM-based",
         "Sources": [
             "https://blog.google/technology/ai/google-palm-2-ai-large-language-model/",
-            "https://ai.google.dev/palm_docs"
+            "https://ai.google.dev/palm_docs",
+            "https://arxiv.org/abs/2305.10403"
         ]
     },
     {


### PR DESCRIPTION
Two kinds of drift in `groundtruth.json`'s `Sources` accept-lists:

1. **Dead canonical URLs.** `github.com/runwayml/stable-diffusion` (Runway deleted the repo, along with the HF model) and `ai.google.dev/palm_docs` (path retired) both 404. Agents can no longer verify them, and citing the live replacements scored 0.
2. **Missing legitimate source.** LAION CLIP accepted only `laion.ai/blog/large-openclip/`; in observed runs agents completed the table 97.5% correctly but cited the official OpenCLIP implementation repo (`github.com/mlfoundations/open_clip`) — which the blog itself documents — and failed on that single cell.

Since `Sources` is an accept-list (any submitted URL matching any entry passes), this change is strictly additive — no previously-passing citation can now fail:

- adds `huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5` (the official relocation of the SD 1.5 weights),
- adds `arxiv.org/abs/2305.10403` (PaLM 2 Technical Report),
- adds `github.com/mlfoundations/open_clip` for LAION CLIP,
- keeps all existing entries.