### PR TITLE
language-school: update renamed CMU admissions URL

### DIFF
--- a/tasks/finalpool/language-school/evaluation/check_local.py
+++ b/tasks/finalpool/language-school/evaluation/check_local.py
@@ -97,7 +97,7 @@ def check_local(agent_workspace, groundtruth_workspace):
             "Toefl_min_score":100,
             "Ielts_accepted":"Yes",
             # CMU SCS Graduate Admissions
-            # (https://www.cs.cmu.edu/academics/graduate-admissions) states
+            # (https://www.cs.cmu.edu/education/graduate-admissions) states
             # "An IELTS score of 7 is equivalent to a TOEFL score of 100",
             # making 7 the effective minimum.  Previously hardcoded as 7.5
             # which doesn't appear in any official CMU source.

--- a/tasks/finalpool/language-school/gt_record.md
+++ b/tasks/finalpool/language-school/gt_record.md
@@ -35,7 +35,7 @@ Due on December 2nd
 
 ## CMU
 
-https://www.cs.cmu.edu/academics/graduate-admissions
+https://www.cs.cmu.edu/education/graduate-admissions
 
 TOEFL 100 (recommended)
 IELTS 7


### PR DESCRIPTION
CMU renamed `cs.cmu.edu/academics/graduate-admissions` → `cs.cmu.edu/education/graduate-admissions` (the old path 301s today, and will eventually rot). Updates the reference in `gt_record.md` and the citation comment in `evaluation/check_local.py`. No grading behavior change.