### PR TITLE
Toolathlon verified ptc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ duplicated_page_id.txt
 
 configs/ports_config.yaml
 configs/port_changes*.json
+
+ptc-*

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Toolathlon is a benchmark to assess language agents' general tool use in realist
 </div>
 
 ## News
+[2026.07.09] 📣 We have also uploaded trajectories for Muse Spark 1.1 to the [**Toolathlon-Verified** trajectories](https://huggingface.co/datasets/hkust-nlp/Toolathlon-Verified_Trajectories/tree/main) dataset on Hugging Face.
+
 [2026.06.30] 🎉 **Toolathlon-Verified** is released. This release marks the verified final version of Toolathlon, with task prompts, ground truths, and evaluators reviewed and aligned for the final benchmark release. We have also uploaded trajectories for 8 models to the [**Toolathlon-Verified** trajectories](https://huggingface.co/datasets/hkust-nlp/Toolathlon-Verified_Trajectories/tree/main) dataset on Hugging Face.
 
 [2025.12.12] 📣 We have set up a new documentation page for common issues and updates, please refer to [UpdateLogs_CommonIssues.md](UpdateLogs_CommonIssues.md) for more details. The document will be updated regularly to track the latest changes and issues.
 
-[2025.12.5] 📣 We have updated the trajectories for 4 new models (gemini-3-pro, claude-4.5-opus, gpt-5.1, deepseek-v3.2-thinking) on [Hugging Face](https://huggingface.co/datasets/hkust-nlp/Toolathlon-Trajectories), take a look if you are interested.
+[2025.12.05] 📣 We have updated the trajectories for 4 new models (gemini-3-pro, claude-4.5-opus, gpt-5.1, deepseek-v3.2-thinking) on [Hugging Face](https://huggingface.co/datasets/hkust-nlp/Toolathlon-Trajectories), take a look if you are interested.
 
 [2025.11.28] 🚀 We have provided a ready-to-use public eval service (you do not need to set anything up!), please refer to [EVAL_SERVICE_README.md](EVAL_SERVICE_README.md) for more details.
 

--- a/configs/mcp_servers/12306.yaml
+++ b/configs/mcp_servers/12306.yaml
@@ -7,6 +7,12 @@ params:
   command: npx
   args:
     - "-y"
+    # The task image already ships 12306-mcp in its npm/npx cache. --prefer-offline
+    # makes npx use that cached package and skip the network revalidation request to
+    # the registry, which under high worker concurrency (20-32 containers at once)
+    # can hang and cause intermittent cold-start timeouts. On a cache miss npx falls
+    # back to the network automatically, so this never causes a failure.
+    - "--prefer-offline"
     - "12306-mcp"
   cwd: "${agent_workspace}"
 cache_tools_list: true

--- a/configs/mcp_servers/12306.yaml
+++ b/configs/mcp_servers/12306.yaml
@@ -7,12 +7,6 @@ params:
   command: npx
   args:
     - "-y"
-    # The task image already ships 12306-mcp in its npm/npx cache. --prefer-offline
-    # makes npx use that cached package and skip the network revalidation request to
-    # the registry, which under high worker concurrency (20-32 containers at once)
-    # can hang and cause intermittent cold-start timeouts. On a cache miss npx falls
-    # back to the network automatically, so this never causes a failure.
-    - "--prefer-offline"
     - "12306-mcp"
   cwd: "${agent_workspace}"
 cache_tools_list: true

--- a/configs/mcp_servers/12306.yaml
+++ b/configs/mcp_servers/12306.yaml
@@ -7,7 +7,13 @@ params:
   command: npx
   args:
     - "-y"
-    - "12306-mcp"
+    # The task image already ships 12306-mcp in its npm/npx cache. --prefer-offline
+    # makes npx use that cached package and skip the network revalidation request to
+    # the registry, which under high worker concurrency (20-32 containers at once)
+    # can hang and cause intermittent cold-start timeouts. On a cache miss npx falls
+    # back to the network automatically, so this never causes a failure.
+    # - "--prefer-offline"
+    - "12306-mcp@0.3.9"
   cwd: "${agent_workspace}"
 cache_tools_list: true
 client_session_timeout_seconds: 20

--- a/eval_client.py
+++ b/eval_client.py
@@ -730,7 +730,7 @@ def run(
     ),
     api_key: Optional[str] = typer.Option(
         None,
-        help="API key for authentication. It is required for public mode, and ignored for private mode. So in private mode please set OPENAI_API_KEY environment variable if your endpoint requires it."
+        help="API key for authentication. It is required for public mode. In private mode it is not sent to the evaluation server; it is forwarded to the local WebSocket client, which otherwise falls back to the TOOLATHLON_OPENAI_API_KEY or OPENAI_API_KEY environment variable."
     ),
     workers: int = typer.Option(
         10,

--- a/eval_client.py
+++ b/eval_client.py
@@ -529,7 +529,7 @@ async def private_worker(
                 sys.executable, "simple_client_ws.py",
                 "--server-url", ws_server_url,
                 "--llm-base-url", vllm_url,
-                "--llm-api-key", vllm_api_key or "",
+                *(["--llm-api-key", vllm_api_key] if vllm_api_key else []),
                 "--job-id", job_id,  # Pass job_id for authentication
                 stdout=log_f,
                 stderr=asyncio.subprocess.STDOUT
@@ -984,7 +984,9 @@ def run(
                 "client_version": CLIENT_VERSION,  # Send client version for compatibility check
                 "mode": mode,
                 "base_url": base_url,
-                "api_key": api_key,
+                # The server never reads the key for private jobs; inference
+                # is proxied through the local WebSocket client.
+                "api_key": api_key if mode == "public" else None,
                 "model_name": model_name,
                 "workers": workers,
                 "custom_job_id": job_id,  # Pass custom job_id if provided
@@ -1132,14 +1134,18 @@ from eval_client import public_worker
 asyncio.run(public_worker('{server_url}', '{final_job_id}', '{output_dir}', {force_redownload}, {trust_env_in_httpx}))
 """
     else:  # private
-        api_key_arg = f"'{api_key}'" if api_key else "None"
+        # The key is handed to the worker via its environment, not its argv.
         worker_code = f"""
 import asyncio
 import sys
 sys.path.insert(0, '{os.path.abspath(os.path.dirname(__file__))}')
 from eval_client import private_worker
-asyncio.run(private_worker('{server_url}', '{final_job_id}', '{client_id}', '{base_url}', {api_key_arg}, {ws_proxy_port}, '{output_dir}', {force_redownload}, {trust_env_in_httpx}))
+asyncio.run(private_worker('{server_url}', '{final_job_id}', '{client_id}', '{base_url}', None, {ws_proxy_port}, '{output_dir}', {force_redownload}, {trust_env_in_httpx}))
 """
+
+    worker_env = os.environ.copy()
+    if mode == "private" and api_key:
+        worker_env["TOOLATHLON_OPENAI_API_KEY"] = api_key
 
     # Start detached background process
     process = subprocess.Popen(
@@ -1148,7 +1154,8 @@ asyncio.run(private_worker('{server_url}', '{final_job_id}', '{client_id}', '{ba
         stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,
         start_new_session=True,
-        cwd=os.getcwd()
+        cwd=os.getcwd(),
+        env=worker_env
     )
 
     typer.echo(f"\n✓ Background worker started (PID: {process.pid})")

--- a/eval_client.py
+++ b/eval_client.py
@@ -772,6 +772,15 @@ def run(
         False,
         help="If enabled, httpx will trust environment proxy settings (HTTP_PROXY, HTTPS_PROXY, etc.)"
     ),
+    programmatic_tool_calling: Optional[bool] = typer.Option(
+        None,
+        "--programmatic-tool-calling/--no-programmatic-tool-calling",
+        help="Per-job override for programmatic tool calling (PTC). If unset, server falls back to its eval-config default. Requires server v1.3+."
+    ),
+    ptc_timeout: Optional[int] = typer.Option(
+        None,
+        help="Per-job override for PTC timeout in seconds (only meaningful when PTC is enabled). Requires server v1.3+."
+    ),
 ):
     """
     Submit and run a Toolathlon evaluation task.
@@ -974,6 +983,10 @@ def run(
     typer.echo(f"  Server: {server_url}")
     if mode == "private":
         typer.echo(f"  WebSocket Proxy Port: {ws_proxy_port}")
+    if programmatic_tool_calling is not None:
+        typer.echo(f"  PTC: {programmatic_tool_calling}")
+    if ptc_timeout is not None:
+        typer.echo(f"  PTC timeout: {ptc_timeout}s")
 
     # Submit task
     try:
@@ -1005,6 +1018,12 @@ def run(
             # Add task_list_content if provided
             if task_list_content:
                 submit_data["task_list_content"] = task_list_content
+
+            # Add PTC overrides if provided (v1.3+)
+            if programmatic_tool_calling is not None:
+                submit_data["programmatic_tool_calling"] = programmatic_tool_calling
+            if ptc_timeout is not None:
+                submit_data["ptc_timeout_seconds"] = ptc_timeout
 
             resp = client.post(
                 f"{server_url}/submit_evaluation",

--- a/eval_server.py
+++ b/eval_server.py
@@ -460,6 +460,30 @@ async def run_command_async(cmd: list, env: dict, log_file: str):
         )
         return process
 
+async def notify_ws_proxy_job_ended(job_id: str, reason: str):
+    """Best-effort notification that releases the private-mode WebSocket slot."""
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.post(
+                f"http://127.0.0.1:{WS_PROXY_PORT}/internal/disconnect_job",
+                params={"job_id": job_id, "reason": reason}
+            )
+
+        if response.status_code != 200:
+            log(f"[Server] Warning: WebSocket proxy rejected cleanup for job {job_id} (HTTP {response.status_code})")
+            return
+
+        result = response.json()
+        if result.get("disconnected"):
+            log(f"[Server] Released WebSocket client for terminal job {job_id} ({reason})")
+        elif result.get("reason") not in {"no_client_connected", "different_job_connected"}:
+            log(f"[Server] Warning: WebSocket proxy did not release job {job_id}: {result}")
+    except Exception as e:
+        # Cleanup notification must never change the evaluation's terminal state.
+        log(f"[Server] Warning: Could not notify WebSocket proxy that job {job_id} ended: {e}")
+
 # ===== Background Task Executor =====
 
 async def execute_evaluation(job_id: str, mode: str, config: Dict[str, Any]):
@@ -587,6 +611,9 @@ async def execute_evaluation(job_id: str, mode: str, config: Dict[str, Any]):
                     current_job["error"] = f"Task exceeded {TIMEOUT_SECONDS//60} minutes"
                 log(f"[Server] Job {job_id} timed out after {elapsed//60:.1f} minutes")
 
+                if mode == "private":
+                    await notify_ws_proxy_job_ended(job_id, "timeout")
+
                 # Record completion time and duration
                 record_job_completion(job_id, client_ip, start_timestamp)
 
@@ -623,6 +650,9 @@ async def execute_evaluation(job_id: str, mode: str, config: Dict[str, Any]):
             current_job["status"] = "completed"
         log(f"[Server] Job {job_id} completed successfully")
 
+        if mode == "private":
+            await notify_ws_proxy_job_ended(job_id, "completed")
+
         # Record completion time and duration
         record_job_completion(job_id, client_ip, start_timestamp)
 
@@ -635,6 +665,9 @@ async def execute_evaluation(job_id: str, mode: str, config: Dict[str, Any]):
             current_job["status"] = "failed"
             current_job["error"] = error_msg
         log(f"[Server] Job {job_id} failed: {error_msg}")
+
+        if mode == "private":
+            await notify_ws_proxy_job_ended(job_id, "failed")
 
         # Record completion time and duration
         record_job_completion(job_id, client_ip, start_timestamp)
@@ -946,8 +979,13 @@ async def validate_job(job_id: str, request: Request):
     if client_host not in ["127.0.0.1", "localhost", "::1"]:
         raise HTTPException(status_code=403, detail="Access denied: localhost only")
 
-    # Check if this job_id matches the current running job
-    if current_job and current_job.get("job_id") == job_id:
+    # A retained terminal job is available for result retrieval, but must no
+    # longer authenticate or retain a WebSocket client.
+    if (
+        current_job
+        and current_job.get("job_id") == job_id
+        and current_job.get("status") == "running"
+    ):
         return {
             "valid": True,
             "job_id": job_id,
@@ -957,6 +995,7 @@ async def validate_job(job_id: str, request: Request):
     else:
         return {
             "valid": False,
+            "status": current_job.get("status") if current_job and current_job.get("job_id") == job_id else "not_found",
             "message": "No active job with this ID"
         }
 
@@ -1095,6 +1134,9 @@ async def cancel_job(job_id: str):
         log(f"[Server] Warning: Failed to clean up {container_runtime} containers: {e}")
 
     current_job["status"] = "cancelled"
+
+    if current_job.get("mode") == "private":
+        await notify_ws_proxy_job_ended(job_id, "cancelled")
 
     # Record completion time and duration (for cancelled jobs)
     record_job_completion(job_id, current_job["client_ip"], current_job["start_timestamp"])

--- a/eval_server.py
+++ b/eval_server.py
@@ -86,6 +86,8 @@ class SubmitEvaluationRequest(BaseModel):
     skip_container_restart: bool = False  # Skip container restart (for debugging/testing only)
     provider: str = "unified"  # Model provider (default: "unified" for backward compatibility with v1.0 clients)
     ws_client_version: Optional[str] = None  # WebSocket client version (required for private mode in v1.3)
+    programmatic_tool_calling: Optional[bool] = None  # Per-job PTC toggle (v1.3+); None means use eval-config default
+    ptc_timeout_seconds: Optional[int] = None  # Per-job PTC timeout in seconds (v1.3+)
 
 class SubmitEvaluationResponse(BaseModel):
     status: str
@@ -580,6 +582,16 @@ async def execute_evaluation(job_id: str, mode: str, config: Dict[str, Any]):
             env["TASK_LIST"] = str(task_list_file)
             log(f"[Server] Using custom task list: {task_list_file}")
 
+        # PTC env injection (v1.3+). main.py reads these env vars and they take
+        # precedence over both the --programmatic_tool_calling CLI flag and the
+        # eval-config JSON value, so per-job overrides win.
+        if config.get('programmatic_tool_calling') is not None:
+            env["TOOLATHLON_PROGRAMMATIC_TOOL_CALLING"] = "true" if config['programmatic_tool_calling'] else "false"
+            log(f"[Server] PTC: programmatic_tool_calling={config['programmatic_tool_calling']}")
+        if config.get('ptc_timeout_seconds') is not None:
+            env["TOOLATHLON_PTC_TIMEOUT"] = str(config['ptc_timeout_seconds'])
+            log(f"[Server] PTC: ptc_timeout_seconds={config['ptc_timeout_seconds']}")
+
         run_process = await run_command_async(
             [
                 "bash", "scripts/run_parallel.sh",
@@ -851,7 +863,9 @@ async def submit_evaluation(request: Request, data: SubmitEvaluationRequest):
         "model_params": data.model_params,
         "task_list_content": data.task_list_content,
         "skip_container_restart": data.skip_container_restart,
-        "provider": data.provider  # Add provider (v1.1+)
+        "provider": data.provider,  # Add provider (v1.1+)
+        "programmatic_tool_calling": data.programmatic_tool_calling,  # v1.3+
+        "ptc_timeout_seconds": data.ptc_timeout_seconds,  # v1.3+
     }
 
     asyncio.create_task(execute_evaluation(job_id, data.mode, config))
@@ -865,6 +879,10 @@ async def submit_evaluation(request: Request, data: SubmitEvaluationRequest):
         log(f"[Server] Using custom task list with {task_count} tasks")
     if data.skip_container_restart:
         log(f"[Server] WARNING: Container restart will be skipped (debugging/testing mode only)")
+    if data.programmatic_tool_calling is not None:
+        log(f"[Server] PTC override: programmatic_tool_calling={data.programmatic_tool_calling}")
+    if data.ptc_timeout_seconds is not None:
+        log(f"[Server] PTC override: ptc_timeout_seconds={data.ptc_timeout_seconds}")
 
     # Prepare rate limit info for response
     rate_limit_info = {

--- a/main.py
+++ b/main.py
@@ -33,17 +33,24 @@ async def main():
 
     ## we override some parameters here
     # we now just set a hard sampling parameters: temperature = 0.6, top_p = 1.0, max_tokens = 4096
-    parser.add_argument("--max_steps_under_single_turn_mode", type=int, default=None, 
+    parser.add_argument("--max_steps_under_single_turn_mode", type=int, default=None,
                        help="Maximum number of steps under single turn mode")
-    parser.add_argument("--model_short_name", type=str, default=None, 
+    parser.add_argument("--model_short_name", type=str, default=None,
                        help="Model name")
-    parser.add_argument("--provider", type=str, default="unified", 
+    parser.add_argument("--provider", type=str, default="unified",
                        help="Provider")
+    parser.add_argument("--programmatic_tool_calling", action="store_true",
+                       help=("Enable programmatic tool calling: a synthetic "
+                             "ptc-programmatic_tool_call tool that runs Python "
+                             "code in a persistent sandbox and proxies MCP tool "
+                             "calls through tools[\"<server>-<tool>\"](...)."))
+    parser.add_argument("--ptc_timeout", type=int, default=None,
+                       help="Per-call timeout (seconds) for programmatic_tool_call. Default 60.")
     args = parser.parse_args()
-    
+
     # Set Proxy (if needed)
     setup_proxy(args.with_proxy)
-    
+
     # Load configurations
     eval_config_dict = read_json(args.eval_config)
     # task_config_dict = read_json(os.path.join(args.task_dir, "task_config.json"))
@@ -53,6 +60,25 @@ async def main():
         eval_config_dict['agent']['model']['provider'] = args.provider
     if args.max_steps_under_single_turn_mode is not None:
         eval_config_dict['global_task_config']['max_steps_under_single_turn_mode'] = args.max_steps_under_single_turn_mode
+
+    # Programmatic tool calling: env var > CLI flag > eval-config default.
+    # Env var lets shell launchers (run_single_*.sh) flip it on without rebuilding
+    # the eval-config JSON.
+    tool_cfg = eval_config_dict.setdefault('agent', {}).setdefault('tool', {})
+    env_ptc = os.getenv("TOOLATHLON_PROGRAMMATIC_TOOL_CALLING")
+    if env_ptc is not None:
+        tool_cfg['programmatic_tool_calling'] = env_ptc.strip().lower() in ("1", "true", "yes", "on")
+    elif args.programmatic_tool_calling:
+        tool_cfg['programmatic_tool_calling'] = True
+
+    env_ptc_timeout = os.getenv("TOOLATHLON_PTC_TIMEOUT")
+    if env_ptc_timeout is not None:
+        try:
+            tool_cfg['ptc_timeout_seconds'] = int(env_ptc_timeout)
+        except ValueError:
+            print_color(f"Invalid TOOLATHLON_PTC_TIMEOUT={env_ptc_timeout!r}, ignoring.", "yellow")
+    elif args.ptc_timeout is not None:
+        tool_cfg['ptc_timeout_seconds'] = args.ptc_timeout
     
     # Parse configurations
     mcp_config, agent_config, user_config = TaskRunner.load_configs(eval_config_dict)

--- a/scripts/decoupled/host_agent_loop.py
+++ b/scripts/decoupled/host_agent_loop.py
@@ -288,7 +288,33 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--with_proxy", action="store_true")
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--allow_resume", action="store_true")
+    parser.add_argument("--programmatic_tool_calling", action="store_true",
+                       help=("Enable programmatic tool calling on the host side: "
+                             "wraps the gateway in a PTC layer that exposes "
+                             "ptc-programmatic_tool_call. Inside the sandbox, code "
+                             "calls gateway tools via tools[\"<gw>-<tool>\"](...)."))
+    parser.add_argument("--ptc_timeout", type=int, default=None,
+                       help="Per-call timeout (seconds) for programmatic_tool_call. Default 60.")
     return parser.parse_args()
+
+
+def _apply_ptc_overrides(eval_config_dict: Dict[str, Any], args: argparse.Namespace) -> None:
+    """Mirror main.py: env var > CLI flag > eval-config default."""
+    tool_cfg = eval_config_dict.setdefault("agent", {}).setdefault("tool", {})
+    env_ptc = os.getenv("TOOLATHLON_PROGRAMMATIC_TOOL_CALLING")
+    if env_ptc is not None:
+        tool_cfg["programmatic_tool_calling"] = env_ptc.strip().lower() in ("1", "true", "yes", "on")
+    elif args.programmatic_tool_calling:
+        tool_cfg["programmatic_tool_calling"] = True
+
+    env_ptc_timeout = os.getenv("TOOLATHLON_PTC_TIMEOUT")
+    if env_ptc_timeout is not None:
+        try:
+            tool_cfg["ptc_timeout_seconds"] = int(env_ptc_timeout)
+        except ValueError:
+            print(f"Invalid TOOLATHLON_PTC_TIMEOUT={env_ptc_timeout!r}, ignoring.")
+    elif args.ptc_timeout is not None:
+        tool_cfg["ptc_timeout_seconds"] = args.ptc_timeout
 
 
 async def run_host_loop(args: argparse.Namespace) -> int:
@@ -296,6 +322,7 @@ async def run_host_loop(args: argparse.Namespace) -> int:
     setup_proxy(args.with_proxy)
 
     eval_config_dict = bundle["eval_config"]
+    _apply_ptc_overrides(eval_config_dict, args)
     mcp_config, agent_config, user_config = TaskRunner.load_configs(eval_config_dict)
     task_config = build_host_task_config(bundle, agent_short_name=agent_config.model.short_name)
 

--- a/scripts/decoupled/tests/test_run_single_decoupled_isolation.py
+++ b/scripts/decoupled/tests/test_run_single_decoupled_isolation.py
@@ -40,9 +40,14 @@ class DecoupledIsolationRunnerTests(unittest.TestCase):
             re.search(r"(?m)^\s*exit\b", self.script[host_exit:restore])
         )
 
+        # No stop/start of the task container between the host loop and the
+        # evaluation, with or without options such as `-t 0` — evaluator-
+        # visible task services must stay up.  cleanup()'s quiesce/restart
+        # lives outside this segment.
         live_container_segment = self.script[host_exit:evaluation]
-        self.assertNotIn(' stop "$CONTAINER_NAME"', live_container_segment)
-        self.assertNotIn(' start "$CONTAINER_NAME"', live_container_segment)
+        self.assertIsNone(
+            re.search(r"\$CONTAINER_RUNTIME (stop|start)\b", live_container_segment)
+        )
 
     def test_evaluator_uses_consumed_private_bundle_and_trusted_inputs(self) -> None:
         evaluation = self.position("# Step 6: Container evaluation")
@@ -91,7 +96,7 @@ class DecoupledIsolationRunnerTests(unittest.TestCase):
         self.assertEqual(self.script.count("task_artifact_guard restore"), 1)
         cleanup_start = self.position("cleanup() {")
         container_stop = self.position(
-            '$CONTAINER_RUNTIME stop "$CONTAINER_NAME"', cleanup_start
+            '$CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME"', cleanup_start
         )
         stash_cleanup = self.position(
             "task_artifact_guard cleanup", container_stop

--- a/scripts/formal_run_v0.json
+++ b/scripts/formal_run_v0.json
@@ -19,7 +19,9 @@
         "tool":{
             "tool_choice": "auto",
             "parallel_tool_calls":true,
-            "max_inner_turns": 2000
+            "max_inner_turns": 2000,
+            "programmatic_tool_calling": false,
+            "ptc_timeout_seconds": 60
         }
     },
     "user":{

--- a/scripts/run_single_containerized.sh
+++ b/scripts/run_single_containerized.sh
@@ -128,12 +128,12 @@ echo "Container name: $CONTAINER_NAME"
 # --- BEGIN: Detect and propagate TOOLATHLON_OPENAI env vars from host to container ---
 EXTRA_ENV_ARGS=()
 if [ ! -z "${TOOLATHLON_OPENAI_BASE_URL+x}" ]; then
-    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL=${TOOLATHLON_OPENAI_BASE_URL}")
+    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL")
     echo "Detected host TOOLATHLON_OPENAI_BASE_URL, will pass into container"
 fi
 
 if [ ! -z "${TOOLATHLON_OPENAI_API_KEY+x}" ]; then
-    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY=${TOOLATHLON_OPENAI_API_KEY}")
+    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY")
     echo "Detected host TOOLATHLON_OPENAI_API_KEY, will pass into container"
 fi
 

--- a/scripts/run_single_containerized.sh
+++ b/scripts/run_single_containerized.sh
@@ -137,6 +137,16 @@ if [ ! -z "${TOOLATHLON_OPENAI_API_KEY+x}" ]; then
     echo "Detected host TOOLATHLON_OPENAI_API_KEY, will pass into container"
 fi
 
+# Forward programmatic-tool-calling toggles into the container.
+if [ ! -z "${TOOLATHLON_PROGRAMMATIC_TOOL_CALLING+x}" ]; then
+    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_PROGRAMMATIC_TOOL_CALLING=${TOOLATHLON_PROGRAMMATIC_TOOL_CALLING}")
+    echo "Detected host TOOLATHLON_PROGRAMMATIC_TOOL_CALLING=${TOOLATHLON_PROGRAMMATIC_TOOL_CALLING}, will pass into container"
+fi
+if [ ! -z "${TOOLATHLON_PTC_TIMEOUT+x}" ]; then
+    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_PTC_TIMEOUT=${TOOLATHLON_PTC_TIMEOUT}")
+    echo "Detected host TOOLATHLON_PTC_TIMEOUT=${TOOLATHLON_PTC_TIMEOUT}, will pass into container"
+fi
+
 # Detect TOOLATHLON_MODEL_PARAMS_FILE - will copy file and set container path later
 HOST_MODEL_PARAMS_FILE=""
 CONTAINER_MODEL_PARAMS_FILE=""

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -228,12 +228,12 @@ esac
 
 if [ "$USE_UNIFIED_MODEL_ENV" = true ]; then
     if [ ! -z "${TOOLATHLON_OPENAI_BASE_URL+x}" ]; then
-        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL=${TOOLATHLON_OPENAI_BASE_URL}")
+        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_BASE_URL")
         echo "Detected host TOOLATHLON_OPENAI_BASE_URL, will pass into container"
     fi
 
     if [ ! -z "${TOOLATHLON_OPENAI_API_KEY+x}" ]; then
-        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY=${TOOLATHLON_OPENAI_API_KEY}")
+        EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_OPENAI_API_KEY")
         echo "Detected host TOOLATHLON_OPENAI_API_KEY, will pass into container"
     fi
 else

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -263,7 +263,9 @@ CURRENT_CONTAINER_BUNDLE=""
 # is captured right before preprocess runs as container root, and
 # DUMPS_RESTORE_PENDING stays 1 until the tree has been handed back, so
 # cleanup() can finish a restoration the main flow never reached (preprocess
-# failure, SIGINT/SIGTERM).
+# failure, SIGINT/SIGTERM).  On the interrupted path cleanup() must quiesce
+# the container before restoring: the exec'd preprocess can outlive its
+# local client and keep writing (see the pending block in cleanup()).
 DUMPS_OWNER=""
 DUMPS_RESTORE_PENDING=0
 
@@ -287,21 +289,38 @@ cleanup() {
         CURRENT_CONTAINER_BUNDLE=""
     fi
 
-    # Finish any pending ownership restoration while the container can still
-    # service exec calls, i.e. before it is stopped.  Best-effort: this covers
-    # preprocess failures and SIGINT/SIGTERM interruptions.
+    # Finish any pending ownership restoration.  Killing the local exec
+    # CLIENT (Ctrl-C, or run_parallel.py's process-group SIGTERM on task
+    # timeout) does not kill the exec'd process inside the container: it
+    # keeps writing root-owned files to the bind mount.  So quiesce first --
+    # stopping the container tears down its PID namespace and every writer
+    # in it -- then restart the now-inert container (its entrypoint is a
+    # plain `sleep`, and reusing the same container keeps the user-namespace
+    # mapping DUMPS_OWNER was captured under) and only then chown.
+    #
+    # The stop comes FIRST and uses -t 0: run_parallel.py escalates its
+    # SIGTERM to SIGKILL after only 3 seconds, PID 1 (`sleep`) can never
+    # honor a graceful stop anyway, and the daemon completes an accepted
+    # stop even if this script is killed before it returns.  Worst case a
+    # truncated cleanup leaves files with the wrong owner but no live
+    # writer, and the next successful run's full-tree hand-off chown
+    # self-heals them.
     if [ "$DUMPS_RESTORE_PENDING" = "1" ]; then
-        if restore_dumps_ownership >/dev/null 2>&1; then
+        $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        if $CONTAINER_RUNTIME start "$CONTAINER_NAME" >/dev/null 2>&1 \
+            && restore_dumps_ownership >/dev/null 2>&1; then
             echo "  ✓ Restored output ownership: $output_folder"
         else
             echo "  Warning: could not restore output ownership: $output_folder" >&2
         fi
     fi
 
-    # Stop and remove container if exists
+    # Stop and remove container if exists.  -t 0 also here: nothing inside
+    # can use a graceful stop (see above), so the default 10s grace is pure
+    # added latency on every exit path.
     if $CONTAINER_RUNTIME ps -aq --filter "name=$CONTAINER_NAME" 2>/dev/null | grep -q .; then
         echo "  Stopping and removing container: $CONTAINER_NAME"
-        $CONTAINER_RUNTIME stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 || true
         $CONTAINER_RUNTIME rm "$CONTAINER_NAME" >/dev/null 2>&1 || true
         echo "  ✓ Container stopped and removed"
     fi

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -678,6 +678,20 @@ if [ -z "$CURRENT_CONTAINER_BUNDLE" ]; then
     exit 1
 fi
 
+# Owner of the bind-mounted output tree as seen from inside the container's
+# user namespace: the invoking host user on rootful Docker/Podman, container
+# root under rootless Podman. Captured before preprocess (which runs as
+# container root) so ownership can be restored afterwards.
+if ! DUMPS_OWNER=$($CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+    stat -c '%u:%g' /workspace/dumps); then
+    echo "✗ Could not determine output ownership inside the container" >&2
+    exit 1
+fi
+if [[ ! "$DUMPS_OWNER" =~ ^[0-9]+:[0-9]+$ ]]; then
+    echo "✗ Invalid output ownership reported by container: $DUMPS_OWNER" >&2
+    exit 1
+fi
+
 PREPROCESS_ARGS=(
     uv run python -m scripts.decoupled.container_preprocess
     --eval_config "$eval_config"
@@ -707,6 +721,15 @@ if [ $PREPROCESS_EXIT_CODE -ne 0 ]; then
     exit $PREPROCESS_EXIT_CODE
 fi
 echo "✓ Preprocess completed"
+
+# Preprocess runs as container root. Restore the output tree to its
+# pre-preprocess owner in the container's user namespace, preserving host
+# writability under both rootful runtimes and rootless Podman.
+if ! $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+    chown -R -- "$DUMPS_OWNER" /workspace/dumps; then
+    echo "✗ Failed to hand output ownership to the host agent" >&2
+    exit 1
+fi
 
 if ! $CONTAINER_RUNTIME cp \
     "$CONTAINER_NAME:$CURRENT_CONTAINER_BUNDLE" \

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -259,6 +259,20 @@ TRUSTED_BUNDLE_FILE=""
 HOST_AGENT_BUNDLE_FILE=""
 CURRENT_CONTAINER_BUNDLE=""
 
+# Ownership-restoration state for the bind-mounted output tree.  DUMPS_OWNER
+# is captured right before preprocess runs as container root, and
+# DUMPS_RESTORE_PENDING stays 1 until the tree has been handed back, so
+# cleanup() can finish a restoration the main flow never reached (preprocess
+# failure, SIGINT/SIGTERM).
+DUMPS_OWNER=""
+DUMPS_RESTORE_PENDING=0
+
+restore_dumps_ownership() {
+    $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+        chown -R -- "$DUMPS_OWNER" /workspace/dumps || return 1
+    DUMPS_RESTORE_PENDING=0
+}
+
 # Cleanup function
 cleanup() {
     cleanup_exit_code=$?
@@ -271,6 +285,17 @@ cleanup() {
         $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
             rm -f -- "$CURRENT_CONTAINER_BUNDLE" >/dev/null 2>&1 || true
         CURRENT_CONTAINER_BUNDLE=""
+    fi
+
+    # Finish any pending ownership restoration while the container can still
+    # service exec calls, i.e. before it is stopped.  Best-effort: this covers
+    # preprocess failures and SIGINT/SIGTERM interruptions.
+    if [ "$DUMPS_RESTORE_PENDING" = "1" ]; then
+        if restore_dumps_ownership >/dev/null 2>&1; then
+            echo "  ✓ Restored output ownership: $output_folder"
+        else
+            echo "  Warning: could not restore output ownership: $output_folder" >&2
+        fi
     fi
 
     # Stop and remove container if exists
@@ -691,6 +716,7 @@ if [[ ! "$DUMPS_OWNER" =~ ^[0-9]+:[0-9]+$ ]]; then
     echo "✗ Invalid output ownership reported by container: $DUMPS_OWNER" >&2
     exit 1
 fi
+DUMPS_RESTORE_PENDING=1
 
 PREPROCESS_ARGS=(
     uv run python -m scripts.decoupled.container_preprocess
@@ -716,20 +742,26 @@ fi
 PREPROCESS_EXIT_CODE=$?
 set -e
 
+# Preprocess runs as container root and may have created files in the
+# bind-mounted output tree even when it failed.  Restore the tree to its
+# pre-preprocess owner in the container's user namespace regardless of the
+# preprocess result, so a failed run cannot strand root-owned files that
+# break the next retry or cleanup with the same PermissionError.
+if ! restore_dumps_ownership; then
+    if [ $PREPROCESS_EXIT_CODE -eq 0 ]; then
+        echo "✗ Failed to hand output ownership to the host agent" >&2
+        exit 1
+    fi
+    # Keep the preprocess exit code authoritative; cleanup() retries the
+    # restoration before the container is stopped.
+    echo "Warning: could not restore output ownership after failed preprocess" >&2
+fi
+
 if [ $PREPROCESS_EXIT_CODE -ne 0 ]; then
     echo "✗ Preprocess failed, exit code: $PREPROCESS_EXIT_CODE"
     exit $PREPROCESS_EXIT_CODE
 fi
 echo "✓ Preprocess completed"
-
-# Preprocess runs as container root. Restore the output tree to its
-# pre-preprocess owner in the container's user namespace, preserving host
-# writability under both rootful runtimes and rootless Podman.
-if ! $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
-    chown -R -- "$DUMPS_OWNER" /workspace/dumps; then
-    echo "✗ Failed to hand output ownership to the host agent" >&2
-    exit 1
-fi
 
 if ! $CONTAINER_RUNTIME cp \
     "$CONTAINER_NAME:$CURRENT_CONTAINER_BUNDLE" \

--- a/scripts/run_single_decoupled.sh
+++ b/scripts/run_single_decoupled.sh
@@ -283,12 +283,6 @@ cleanup() {
     echo ""
     echo "Performing cleanup..."
 
-    if [ -n "$CURRENT_CONTAINER_BUNDLE" ]; then
-        $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
-            rm -f -- "$CURRENT_CONTAINER_BUNDLE" >/dev/null 2>&1 || true
-        CURRENT_CONTAINER_BUNDLE=""
-    fi
-
     # Finish any pending ownership restoration.  Killing the local exec
     # CLIENT (Ctrl-C, or run_parallel.py's process-group SIGTERM on task
     # timeout) does not kill the exec'd process inside the container: it
@@ -298,21 +292,40 @@ cleanup() {
     # plain `sleep`, and reusing the same container keeps the user-namespace
     # mapping DUMPS_OWNER was captured under) and only then chown.
     #
-    # The stop comes FIRST and uses -t 0: run_parallel.py escalates its
+    # The stop is cleanup's FIRST container operation -- ahead even of the
+    # bundle removal below -- and uses -t 0: run_parallel.py escalates its
     # SIGTERM to SIGKILL after only 3 seconds, PID 1 (`sleep`) can never
     # honor a graceful stop anyway, and the daemon completes an accepted
-    # stop even if this script is killed before it returns.  Worst case a
-    # truncated cleanup leaves files with the wrong owner but no live
-    # writer, and the next successful run's full-tree hand-off chown
+    # stop even if this script is killed before it returns, whereas an exec
+    # needs this client to survive the whole round-trip.  Nothing may spend
+    # the kill window before the stop has been submitted.
+    #
+    # The stop's exit status gates the restoration: `start` returns 0 on an
+    # already-running container, so it proves nothing about the writer --
+    # only a successful stop does.  If the stop fails, skip the chown
+    # entirely rather than hand the tree over under a live writer; the
+    # teardown below retries the stop.  Worst case files are left with the
+    # wrong owner, and the next successful run's full-tree hand-off chown
     # self-heals them.
     if [ "$DUMPS_RESTORE_PENDING" = "1" ]; then
-        $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 || true
-        if $CONTAINER_RUNTIME start "$CONTAINER_NAME" >/dev/null 2>&1 \
+        if $CONTAINER_RUNTIME stop -t 0 "$CONTAINER_NAME" >/dev/null 2>&1 \
+            && $CONTAINER_RUNTIME start "$CONTAINER_NAME" >/dev/null 2>&1 \
             && restore_dumps_ownership >/dev/null 2>&1; then
             echo "  ✓ Restored output ownership: $output_folder"
         else
             echo "  Warning: could not restore output ownership: $output_folder" >&2
         fi
+    fi
+
+    # Remove the in-container bundle copy on early exits (the normal flow
+    # discards it right after preprocess).  Best-effort and deliberately
+    # AFTER the quiesce: if the container is not running anymore the exec
+    # fails harmlessly and the unconditional `rm` below destroys the
+    # container filesystem, bundle included.
+    if [ -n "$CURRENT_CONTAINER_BUNDLE" ]; then
+        $CONTAINER_RUNTIME exec "$CONTAINER_NAME" \
+            rm -f -- "$CURRENT_CONTAINER_BUNDLE" >/dev/null 2>&1 || true
+        CURRENT_CONTAINER_BUNDLE=""
     fi
 
     # Stop and remove container if exists.  -t 0 also here: nothing inside

--- a/simple_client_ws.py
+++ b/simple_client_ws.py
@@ -11,6 +11,7 @@ import asyncio
 import httpx
 import argparse
 import json
+import os
 from datetime import datetime
 from websockets import connect, ConnectionClosedError
 
@@ -318,7 +319,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="WebSocket Proxy Client")
     parser.add_argument("--server-url", required=True, help="Server URL (e.g., http://47.253.6.47:8080)")
     parser.add_argument("--llm-base-url", required=True, help="Real LLM base URL (e.g., https://api.deepseek.com/v1)")
-    parser.add_argument("--llm-api-key", required=True, help="Real LLM API key")
+    parser.add_argument(
+        "--llm-api-key",
+        default=os.environ.get("TOOLATHLON_OPENAI_API_KEY"),
+        required="TOOLATHLON_OPENAI_API_KEY" not in os.environ,
+        help="Real LLM API key; defaults to TOOLATHLON_OPENAI_API_KEY",
+    )
     parser.add_argument("--job-id", required=False, help="Job ID for authentication (required by server)")
 
     args = parser.parse_args()

--- a/simple_client_ws.py
+++ b/simple_client_ws.py
@@ -321,9 +321,11 @@ if __name__ == "__main__":
     parser.add_argument("--llm-base-url", required=True, help="Real LLM base URL (e.g., https://api.deepseek.com/v1)")
     parser.add_argument(
         "--llm-api-key",
-        default=os.environ.get("TOOLATHLON_OPENAI_API_KEY"),
-        required="TOOLATHLON_OPENAI_API_KEY" not in os.environ,
-        help="Real LLM API key; defaults to TOOLATHLON_OPENAI_API_KEY",
+        default=os.environ.get(
+            "TOOLATHLON_OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY", "")
+        ),
+        help="Real LLM API key; defaults to TOOLATHLON_OPENAI_API_KEY, then "
+             "OPENAI_API_KEY, then empty for endpoints without authentication",
     )
     parser.add_argument("--job-id", required=False, help="Job ID for authentication (required by server)")
 

--- a/simple_server_ws.py
+++ b/simple_server_ws.py
@@ -75,8 +75,67 @@ cancelled_requests: set = set()  # Cancelled request ID blacklist
 rejected_connections: Dict[str, int] = {}  # IP -> count of rejections (for statistics)
 last_stats_time: float = 0  # Last time we printed statistics
 push_timeout_manager = AdaptiveTimeout(initial_timeout=60.0, min_timeout=10.0, max_timeout=300.0)  # 推送超时管理器
+JOB_VALIDATION_INTERVAL_SECONDS = 30.0
+JOB_VALIDATION_TIMEOUT_SECONDS = 5.0
 
 # ===== WebSocket Management =====
+
+async def fetch_job_validation(job_id: str) -> Optional[dict]:
+    """Return eval-server validation data, or None on a transient validation failure."""
+    import httpx
+
+    eval_port = getattr(app.state, 'eval_port', 8080)
+    try:
+        async with httpx.AsyncClient(timeout=JOB_VALIDATION_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                f"http://localhost:{eval_port}/internal/validate_job",
+                params={"job_id": job_id}
+            )
+
+        if response.status_code != 200:
+            log(f"[Server] Job validation failed for {job_id} (HTTP {response.status_code})")
+            return {"valid": None, "http_status": response.status_code}
+
+        return response.json()
+    except Exception as e:
+        # A temporary eval-server failure must not evict an otherwise healthy client.
+        log(f"[Server] Job validation unavailable for {job_id}: {e}")
+        return None
+
+async def monitor_job_lifecycle(job_id: str):
+    """Periodically stop serving a client once its evaluation job is no longer active."""
+    while True:
+        await asyncio.sleep(JOB_VALIDATION_INTERVAL_SECONDS)
+        result = await fetch_job_validation(job_id)
+
+        # None means validation was temporarily unavailable. Only an explicit
+        # valid=false response is authoritative enough to close the connection.
+        if result is not None and result.get("valid") is False:
+            status = result.get("status", "not active")
+            log(f"[Server] Job {job_id} is no longer active (status: {status}); releasing WebSocket slot")
+            return "job_inactive"
+
+async def close_finished_job_websocket(websocket: WebSocket, job_id: str, reason: str):
+    """Notify and close a WebSocket whose evaluation job reached a terminal state."""
+    try:
+        await asyncio.wait_for(
+            websocket.send_json({
+                "type": "error",
+                "code": "job_ended",
+                "message": f"Evaluation job {job_id} is no longer active ({reason})"
+            }),
+            timeout=5.0
+        )
+    except Exception as e:
+        log(f"[Server] Could not notify WebSocket client that job {job_id} ended: {e}")
+
+    try:
+        await asyncio.wait_for(
+            websocket.close(code=1000, reason="Evaluation job ended"),
+            timeout=5.0
+        )
+    except Exception as e:
+        log(f"[Server] Could not gracefully close WebSocket for job {job_id}: {e}")
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket, job_id: str = None):
@@ -109,39 +168,29 @@ async def websocket_endpoint(websocket: WebSocket, job_id: str = None):
             pass
         return
 
-    # Verify job_id with eval_server
-    import httpx
-    eval_port = getattr(app.state, 'eval_port', 8080)  # Default to 8080 for backward compatibility
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(
-                f"http://localhost:{eval_port}/internal/validate_job",
-                params={"job_id": job_id}
-            )
-            if resp.status_code == 200:
-                result = resp.json()
-                if not result.get("valid"):
-                    log(f"[Server] ⛔ REJECT connection from {client_addr} - invalid job_id: {job_id}")
-                    try:
-                        await websocket.send_json({"type": "error", "message": f"Invalid or expired job_id: {job_id}"})
-                        await websocket.close()
-                    except Exception:
-                        pass
-                    return
-                # Job ID is valid, log job info
-                log(f"[Server] ✓ Job validation passed: {job_id} (mode: {result.get('mode')})")
-            else:
-                log(f"[Server] ⛔ REJECT connection from {client_addr} - validation failed (HTTP {resp.status_code})")
-                try:
-                    await websocket.send_json({"type": "error", "message": "Job validation failed"})
-                    await websocket.close()
-                except Exception:
-                    pass
-                return
-    except Exception as e:
-        log(f"[Server] ⚠️  Warning: Could not validate job_id (eval_server unreachable): {e}")
-        log(f"[Server] Allowing connection anyway (fallback mode)")
-        # Allow connection if validation service is down (backward compatibility)
+    # Verify job_id with eval_server. Preserve the existing fallback behavior if
+    # the eval server is temporarily unavailable.
+    validation = await fetch_job_validation(job_id)
+    if validation is None:
+        log("[Server] Allowing connection because job validation is temporarily unavailable")
+    elif validation.get("valid") is None:
+        log(f"[Server] ⛔ REJECT connection from {client_addr} - job validation failed")
+        try:
+            await websocket.send_json({"type": "error", "message": "Job validation failed"})
+            await websocket.close()
+        except Exception:
+            pass
+        return
+    elif not validation.get("valid", False):
+        log(f"[Server] ⛔ REJECT connection from {client_addr} - invalid job_id: {job_id}")
+        try:
+            await websocket.send_json({"type": "error", "message": f"Invalid or expired job_id: {job_id}"})
+            await websocket.close()
+        except Exception:
+            pass
+        return
+    else:
+        log(f"[Server] ✓ Job validation passed: {job_id} (mode: {validation.get('mode')})")
 
     # Check if there is already a Client connected
     if connected_client is not None:
@@ -165,16 +214,18 @@ async def websocket_endpoint(websocket: WebSocket, job_id: str = None):
     # Create two tasks
     task_handle_messages = None
     task_push_requests = None
+    task_monitor_job = None
     disconnect_reason = "unknown"
 
     try:
         # Use create_task instead of gather,这样可以更好地控制取消
         task_handle_messages = asyncio.create_task(handle_client_messages(websocket))
         task_push_requests = asyncio.create_task(push_requests_to_client(websocket))
+        task_monitor_job = asyncio.create_task(monitor_job_lifecycle(job_id))
 
         # Wait for any task to complete (usually because of connection closed)
         done, pending = await asyncio.wait(
-            [task_handle_messages, task_push_requests],
+            [task_handle_messages, task_push_requests, task_monitor_job],
             return_when=asyncio.FIRST_COMPLETED
         )
 
@@ -191,16 +242,22 @@ async def websocket_endpoint(websocket: WebSocket, job_id: str = None):
         # Check exceptions of completed tasks
         for task in done:
             try:
-                task.result()
-                disconnect_reason = "normal"
+                result = task.result()
+                if task is task_monitor_job and result == "job_inactive":
+                    disconnect_reason = "job_inactive"
+                elif disconnect_reason == "unknown":
+                    disconnect_reason = "normal"
             except WebSocketDisconnect:
-                disconnect_reason = "client_disconnect"
+                if disconnect_reason == "unknown":
+                    disconnect_reason = "client_disconnect"
                 log(f"[Server] 🔌 Client DISCONNECTED: {client_addr} (reason: client initiated)")
             except asyncio.TimeoutError:
-                disconnect_reason = "timeout"
+                if disconnect_reason == "unknown":
+                    disconnect_reason = "timeout"
                 log(f"[Server] 🔌 Client DISCONNECTED: {client_addr} (reason: timeout - no heartbeat)")
             except Exception as e:
-                disconnect_reason = "error"
+                if disconnect_reason == "unknown":
+                    disconnect_reason = "error"
                 log(f"[Server] 🔌 Client DISCONNECTED: {client_addr} (reason: error - {e})")
 
     except Exception as e:
@@ -209,19 +266,23 @@ async def websocket_endpoint(websocket: WebSocket, job_id: str = None):
         import traceback
         log(f"[Server] Stack: {traceback.format_exc()}")
     finally:
-        # Ensure cleanup (this will always execute)
-        connected_client = None
-        connected_client_addr = None
-        connected_client_job_id = None  # Clear job_id on disconnect
-
         # Cancel all possible running tasks
-        for task in [task_handle_messages, task_push_requests]:
+        for task in [task_handle_messages, task_push_requests, task_monitor_job]:
             if task is not None and not task.done():
                 task.cancel()
                 try:
                     await task
                 except:
                     pass
+
+        if disconnect_reason == "job_inactive":
+            await close_finished_job_websocket(websocket, job_id, "job is no longer running")
+
+        # Ensure an old connection cannot clear a newer connection's state.
+        if connected_client is websocket:
+            connected_client = None
+            connected_client_addr = None
+            connected_client_job_id = None
 
         log(f"[Server] Cleanup completed for {client_addr}, slot now available (reason: {disconnect_reason})")
 
@@ -510,6 +571,31 @@ async def proxy_chat(request: Request, request_data: dict):
 async def proxy_responses(request: Request, request_data: dict):
     """Proxy for OpenAI Responses API"""
     return await _handle_proxy_request(request, request_data, "/responses")
+
+@app.post("/internal/disconnect_job")
+async def disconnect_job_websocket(job_id: str, request: Request, reason: str = "finished"):
+    """Close the connected client for a terminal job. Local eval-server calls only."""
+    client_host = request.client.host if request.client else "unknown"
+    if client_host not in ["127.0.0.1", "localhost", "::1"]:
+        return JSONResponse(
+            content={"detail": "Access denied: localhost only"},
+            status_code=403
+        )
+
+    if connected_client is None:
+        return {"disconnected": False, "reason": "no_client_connected"}
+
+    if connected_client_job_id != job_id:
+        return {
+            "disconnected": False,
+            "reason": "different_job_connected",
+            "connected_job_id": connected_client_job_id
+        }
+
+    websocket = connected_client
+    log(f"[Server] Eval server requested WebSocket release for job {job_id} (reason: {reason})")
+    await close_finished_job_websocket(websocket, job_id, reason)
+    return {"disconnected": True, "job_id": job_id}
 
 @app.get("/")
 async def root():

--- a/tasks/finalpool/train-ticket-plan/evaluation/main.py
+++ b/tasks/finalpool/train-ticket-plan/evaluation/main.py
@@ -5,84 +5,84 @@ from pathlib import Path
 from utils.general.helper import read_json
 from datetime import datetime, timedelta
 import json
+import re
 from utils.general.helper import normalize_str
 import time
 
 def resolve_returned_result(res_str: str):
     res_list = []
-    current_train_info = {}
-    
+    current_train_info = None
 
-    for lid,line in enumerate(res_str.split("\n")):
-        if line.strip() == "车次 | 出发站 -> 到达站 | 出发时间 -> 到达时间 | 历时":
+    # 0.3.5 includes "(实际车次train_no: ...)" while 0.3.9 omits it.
+    train_pattern = re.compile(
+        r"^(?P<train>[A-Za-z0-9]+)"
+        r"(?:\(实际车次train_no:\s*(?P<actual>[^)]+)\))?"
+        r"\s+(?P<from_station>.*?)"
+        r"\(telecode:\s*(?P<from_code>[^)]+)\)"
+        r"\s*->\s*"
+        r"(?P<to_station>.*?)"
+        r"\(telecode:\s*(?P<to_code>[^)]+)\)"
+        r"\s+(?P<departure>\d{2}:\d{2})"
+        r"\s*->\s*"
+        r"(?P<arrival>\d{2}:\d{2})"
+        r"\s+历时：(?P<duration>\S+)$"
+    )
+    seat_pattern = re.compile(
+        r"^-\s+(?P<seat_type>.*?):\s+"
+        r"(?P<count>\S+)\s+"
+        r"(?P<price>\d+(?:\.\d+)?)元$"
+    )
+
+    for raw_line in res_str.splitlines():
+        line = raw_line.strip()
+        if not line:
             continue
-        if line.strip() == "":
+
+        # Ignore spacing differences between the 0.3.5 and 0.3.9 headers.
+        if line.replace(" ", "") == "车次|出发站->到达站|出发时间->到达时间|历时":
             continue
-        if "(实际车次train_no:" in line:
-            if current_train_info:
+
+        train_match = train_pattern.match(line)
+        if train_match:
+            if current_train_info is not None:
                 res_list.append(current_train_info)
-                current_train_info = {}
-            # 第一个括号左边的是车次 (The left of the first bracket is the train number)
-            # 第一个括号中间的，分别是 实际车次train_no: xxxx (The middle of the first bracket is the actual train number: xxxx)
-            # 第一到第二个括号中间的是始发站 (The middle of the first and second brackets is the departure station)
-            # 第二个括号中间的是telecode: xxx (The middle of the second bracket is the departure station telecode: xxx)
-            # 第二到第三个括号是 -> 终点站 (The middle of the second and third brackets is the arrival station: xxx -> xxx)
-            # 第三个括号中间的是 telecode: xxx (The middle of the third bracket is the arrival station telecode: xxx)
-            # 第三个括号往后依次是 xx:xx -> xx:xx 历时：xx:xx (The rest of the third bracket is the duration: xx:xx -> xx:xx 历时：xx:xx)
 
-            # 请先找到各个括号 (Please find all the brackets first)
-            first_left_bracket_index = line.find("(")
-            first_right_bracket_index = line.find(")")
-            first_left_bracket_index_2 = line.find("(", first_left_bracket_index+1)
-            first_right_bracket_index_2 = line.find(")", first_left_bracket_index_2+1)
-            first_left_bracket_index_3 = line.find("(", first_right_bracket_index_2+1)
-            first_right_bracket_index_3 = line.find(")", first_left_bracket_index_3+1)
-            
-            # 然后依次解析 (Then parse them one by one)
-            train_no = line[:first_left_bracket_index].strip()
-            train_no_actual = line[first_left_bracket_index+1:first_right_bracket_index].strip()
-            train_no_actual = train_no_actual.split(":")[1].strip()
-            from_station = line[first_right_bracket_index+1:first_left_bracket_index_2].strip()
-            from_station_telecode = line[first_left_bracket_index_2+1:first_right_bracket_index_2].strip('telecode: ')
-            to_station = line[first_right_bracket_index_2+1:first_left_bracket_index_3].strip().strip('->').strip()
-            to_station_telecode = line[first_left_bracket_index_3+1:first_right_bracket_index_3].strip('telecode: ')
-            departure_time_meta = line[first_right_bracket_index_3+1:].strip()
-            departure_time = departure_time_meta.split("->")[0].strip()
-            arrival_time = departure_time_meta.split("->")[1].split("历时：")[0].strip()
-            duration = departure_time_meta.split("历时：")[1].strip()
-            current_train_info['train_number'] = train_no
-            current_train_info['train_number_actual'] = train_no_actual
-            current_train_info['from_station'] = from_station
-            current_train_info['from_station_telecode'] = from_station_telecode
-            current_train_info['to_station'] = to_station
-            current_train_info['to_station_telecode'] = to_station_telecode
-            current_train_info['departure_time'] = departure_time
-            current_train_info['arrival_time'] = arrival_time
-            current_train_info['duration'] = duration
+            data = train_match.groupdict()
+            current_train_info = {
+                'train_number': data['train'],
+                'train_number_actual': data['actual'],
+                'from_station': data['from_station'].strip(),
+                'from_station_telecode': data['from_code'].strip(),
+                'to_station': data['to_station'].strip(),
+                'to_station_telecode': data['to_code'].strip(),
+                'departure_time': data['departure'],
+                'arrival_time': data['arrival'],
+                'duration': data['duration'],
+                'seats': [],
+            }
+            continue
 
-        else:
-            # 解析座位信息 (Parse the seat information)
-            if line.startswith("- "):
-                # 解析座位信息 (Parse the seat information)
-                linex = line[2:]
-                seat_type = linex.split()[0].rstrip(":")
-                seat_num_xx = linex.split()[1]
-                if "无票" in seat_num_xx:
-                    seat_num = 0
-                elif "有票" in seat_num_xx:
-                    seat_num = 20
-                else:
-                    seat_num = int(seat_num_xx.lstrip("剩余").rstrip("张票"))
-                seat_price = int(linex.split()[2].rstrip("元"))
-                if 'seats' not in current_train_info:
-                    current_train_info['seats'] = []
-                current_train_info['seats'].append({'seat_type': seat_type, 
-                                                    'seat_num': seat_num, 
-                                                    'seat_price': seat_price})
+        seat_match = seat_pattern.match(line)
+        if seat_match and current_train_info is not None:
+            data = seat_match.groupdict()
+            seat_num_text = data['count']
+            if "无票" in seat_num_text:
+                seat_num = 0
+            elif "有票" in seat_num_text:
+                seat_num = 20
             else:
-                raise Exception(f"解析座位信息失败: {line}")   # Failed to parse the seat information (Failed to parse the seat information)
+                seat_num = int(seat_num_text.removeprefix("剩余").removesuffix("张票"))
 
-    if current_train_info:
+            current_train_info['seats'].append({
+                'seat_type': data['seat_type'],
+                'seat_num': seat_num,
+                'seat_price': float(data['price']),
+            })
+            continue
+
+        raise ValueError(f"无法解析12306返回内容 (Failed to parse 12306 output): {line}")
+
+    if current_train_info is not None:
         res_list.append(current_train_info)
 
     return res_list

--- a/tests/decoupled/fake_bin/docker
+++ b/tests/decoupled/fake_bin/docker
@@ -10,6 +10,11 @@
 #   FAKE_PREPROCESS_BEHAVIOR  succeed (default) | fail:<code> | hang
 #   FAKE_CHOWN_BEHAVIOR       succeed (default) | fail
 #   FAKE_START_BEHAVIOR       succeed (default) | fail
+#   FAKE_STOP_BEHAVIOR        succeed (default) | fail-once -- the FIRST
+#                             stop exits nonzero WITHOUT stopping anything
+#                             (writer stays alive, `running` stays), like a
+#                             daemon that rejected the request; later stops
+#                             behave normally so teardown still completes
 #   FAKE_DUMPS_OWNER          uid:gid reported for /workspace/dumps
 #                             (default 1000:1000)
 #
@@ -51,6 +56,17 @@ case "$cmd" in
         exit 0
         ;;
     stop)
+        # fail-once models a stop the daemon rejects while the container
+        # keeps running: nothing is killed, `running` stays, and the exit
+        # code is the runner's ONLY hint -- a later `start` still succeeds
+        # (see below), so a runner that ignores this failure would chown
+        # straight into the live writer.
+        if [ "${FAKE_STOP_BEHAVIOR:-succeed}" = "fail-once" ] \
+            && [ ! -e "$STATE/stop_failed_once" ]; then
+            touch "$STATE/stop_failed_once"
+            echo "stop-fail $*" >> "$STATE/events"
+            exit 1
+        fi
         # Tearing down the container kills every process in its PID
         # namespace, including exec'd ones the client abandoned.  Record
         # whether the inner writer was still alive when stop arrived, then
@@ -69,6 +85,9 @@ case "$cmd" in
         exit 0
         ;;
     start)
+        # Like real docker/podman, `start` on an already-running container
+        # is a no-op SUCCESS -- which is exactly why the runner may not use
+        # it as a stopped-state check after a failed stop.
         echo "start $*" >> "$STATE/events"
         case "${FAKE_START_BEHAVIOR:-succeed}" in
             fail)

--- a/tests/decoupled/fake_bin/docker
+++ b/tests/decoupled/fake_bin/docker
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Fake container runtime for the run_single_decoupled.sh regression tests.
+#
+# The stub records every invocation to $FAKE_RUNTIME_STATE/calls.log, keeps
+# coarse container state as marker files (created/running), and appends the
+# events the tests assert on (preprocess-start, chown, stop) to
+# $FAKE_RUNTIME_STATE/events in arrival order.
+#
+# Behavior knobs (environment):
+#   FAKE_PREPROCESS_BEHAVIOR  succeed (default) | fail:<code> | hang
+#   FAKE_CHOWN_BEHAVIOR       succeed (default) | fail
+#   FAKE_DUMPS_OWNER          uid:gid reported for /workspace/dumps
+#                             (default 1000:1000)
+set -u
+
+STATE="${FAKE_RUNTIME_STATE:?FAKE_RUNTIME_STATE must be set}"
+printf '%s\n' "$0 $*" >> "$STATE/calls.log"
+
+cmd="${1:-}"
+[ $# -gt 0 ] && shift
+
+case "$cmd" in
+    run)
+        touch "$STATE/created" "$STATE/running"
+        echo "fakecontainer0123"
+        exit 0
+        ;;
+    ps)
+        # `ps -q` lists running containers, `ps -aq` includes stopped ones.
+        all=false
+        for arg in "$@"; do
+            [ "$arg" = "-aq" ] && all=true
+        done
+        if [ "$all" = true ]; then
+            [ -e "$STATE/created" ] && echo "fakecontainer0123"
+        else
+            [ -e "$STATE/running" ] && echo "fakecontainer0123"
+        fi
+        exit 0
+        ;;
+    stop)
+        echo "stop" >> "$STATE/events"
+        rm -f "$STATE/running"
+        exit 0
+        ;;
+    rm)
+        rm -f "$STATE/created"
+        exit 0
+        ;;
+    cp)
+        exit 0
+        ;;
+    logs)
+        echo "fake container logs"
+        exit 0
+        ;;
+    version)
+        echo "fake runtime version"
+        exit 0
+        ;;
+    exec)
+        # Strip exec options so $1 becomes the container name.
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --env) shift 2 ;;
+                -t|-i|-it|-ti) shift ;;
+                *) break ;;
+            esac
+        done
+        [ $# -gt 0 ] && shift  # container name
+        inner="$*"
+        case "$inner" in
+            "echo "*)
+                echo "container ready"
+                exit 0
+                ;;
+            "mkdir "*|"rm "*|"chmod "*|"bash "*|"which "*)
+                exit 0
+                ;;
+            "kind version")
+                echo "kind v0.20.0 fake"
+                exit 0
+                ;;
+            "docker version"|"podman version")
+                exit 0
+                ;;
+            "mktemp "*)
+                echo "/run/fake-decoupled-bundle.json"
+                exit 0
+                ;;
+            "stat -c "*)
+                echo "${FAKE_DUMPS_OWNER:-1000:1000}"
+                exit 0
+                ;;
+            "chown -R -- "*)
+                echo "$inner" >> "$STATE/events"
+                case "${FAKE_CHOWN_BEHAVIOR:-succeed}" in
+                    fail) exit 1 ;;
+                    *) exit 0 ;;
+                esac
+                ;;
+            *container_preprocess*)
+                echo "preprocess-start" >> "$STATE/events"
+                touch "$STATE/preprocess_started"
+                case "${FAKE_PREPROCESS_BEHAVIOR:-succeed}" in
+                    fail:*)
+                        exit "${FAKE_PREPROCESS_BEHAVIOR#fail:}"
+                        ;;
+                    hang)
+                        sleep 120
+                        exit 0
+                        ;;
+                    *)
+                        exit 0
+                        ;;
+                esac
+                ;;
+            *)
+                echo "unhandled-exec $inner" >> "$STATE/events"
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/tests/decoupled/fake_bin/docker
+++ b/tests/decoupled/fake_bin/docker
@@ -9,8 +9,20 @@
 # Behavior knobs (environment):
 #   FAKE_PREPROCESS_BEHAVIOR  succeed (default) | fail:<code> | hang
 #   FAKE_CHOWN_BEHAVIOR       succeed (default) | fail
+#   FAKE_START_BEHAVIOR       succeed (default) | fail
 #   FAKE_DUMPS_OWNER          uid:gid reported for /workspace/dumps
 #                             (default 1000:1000)
+#
+# Signal-semantics model (matches real docker/podman, verified against
+# rootful Docker 29.x): the local `docker exec` process is only an API
+# client.  Killing it -- even with a process-group signal -- does NOT kill
+# the exec'd process inside the container; that process lives in the
+# container's PID namespace and dies only when the container is torn down.
+# The `hang` behavior therefore detaches an "inner writer" into its own
+# session (perl POSIX::setsid; macOS has no setsid(1)) which keeps appending
+# `inner-write` events after the client is gone, and fake `stop` is what
+# kills it -- recording `stop-writer-alive` first if it was still running,
+# which is the observable proof that a group signal alone did not stop it.
 set -u
 
 STATE="${FAKE_RUNTIME_STATE:?FAKE_RUNTIME_STATE must be set}"
@@ -39,8 +51,31 @@ case "$cmd" in
         exit 0
         ;;
     stop)
-        echo "stop" >> "$STATE/events"
+        # Tearing down the container kills every process in its PID
+        # namespace, including exec'd ones the client abandoned.  Record
+        # whether the inner writer was still alive when stop arrived, then
+        # kill it and wait until it is gone -- when real `stop` returns,
+        # nothing inside the container is running anymore.
+        if [ -f "$STATE/inner_writer_pid" ]; then
+            writer_pid=$(cat "$STATE/inner_writer_pid")
+            if kill -0 "$writer_pid" 2>/dev/null; then
+                echo "stop-writer-alive" >> "$STATE/events"
+                kill -9 "$writer_pid" 2>/dev/null
+                while kill -0 "$writer_pid" 2>/dev/null; do sleep 0.01; done
+            fi
+        fi
+        echo "stop $*" >> "$STATE/events"
         rm -f "$STATE/running"
+        exit 0
+        ;;
+    start)
+        echo "start $*" >> "$STATE/events"
+        case "${FAKE_START_BEHAVIOR:-succeed}" in
+            fail)
+                exit 1
+                ;;
+        esac
+        touch "$STATE/running"
         exit 0
         ;;
     rm)
@@ -107,6 +142,22 @@ case "$cmd" in
                         exit "${FAKE_PREPROCESS_BEHAVIOR#fail:}"
                         ;;
                     hang)
+                        # Spawn the container-side process as its own session
+                        # leader so group-delivered signals kill only this
+                        # client, then block like the real exec client does.
+                        # The writer appends `inner-write` events (a stand-in
+                        # for creating root-owned files in the bind mount)
+                        # until fake `stop` kills it; the loop is bounded so
+                        # a failed scenario cannot leak it for long.
+                        perl -MPOSIX -e 'POSIX::setsid(); exec @ARGV or die "exec failed: $!"' \
+                            bash -c '
+                                i=0
+                                while [ "$i" -lt 600 ]; do
+                                    echo "inner-write $i" >> "$FAKE_RUNTIME_STATE/events"
+                                    i=$((i + 1))
+                                    sleep 0.05
+                                done' &
+                        echo $! > "$STATE/inner_writer_pid"
                         sleep 120
                         exit 0
                         ;;

--- a/tests/decoupled/fake_bin/podman
+++ b/tests/decoupled/fake_bin/podman
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Podman alias for the fake container runtime used by the regression tests.
+exec "$(dirname "$0")/docker" "$@"

--- a/tests/decoupled/fake_bin/uv
+++ b/tests/decoupled/fake_bin/uv
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fake `uv` for the run_single_decoupled.sh regression tests.  Answers the
+# runner's host-side python probes without needing a real environment; the
+# probes are recognized by distinctive substrings of their inline code.
+set -u
+
+case "$*" in
+    *podman_or_docker*)
+        echo "docker"
+        ;;
+    *instance_prefix*)
+        echo ""
+        ;;
+    *socket.socket*)
+        echo "18999"
+        ;;
+    *)
+        # Anything else (bundle validation, artifact guard, ...) is beyond
+        # the failure paths under test; succeed quietly.
+        exit 0
+        ;;
+esac

--- a/tests/decoupled/test_ownership_restore.sh
+++ b/tests/decoupled/test_ownership_restore.sh
@@ -15,7 +15,9 @@
 # The container runtime (docker/podman) and the host-side `uv` probes are
 # replaced with fakes from tests/decoupled/fake_bin; no real containers are
 # involved.  The fakes record the commands the runner issues, and the tests
-# assert on that recorded event sequence plus the runner's exit code.  See
+# assert on that recorded event sequence plus the runner's exit code -- and,
+# for orderings the events file cannot see (execs it does not record, like
+# the bundle rm), on the complete calls.log invocation order.  See
 # fake_bin/docker for the client/container signal-semantics model.
 #
 # Corner-case -> coverage map:
@@ -35,11 +37,15 @@
 #           (quiesce-before-restore); `start` sits between them; the last
 #           `inner-write` precedes the cleanup chown (the race is closed)
 #   C5 run_parallel.py escalates SIGTERM to SIGKILL after only 3 seconds
-#        -> s4/s5: the pending path's FIRST container action is `stop`
-#           with `-t 0` (no 10s grace for a `sleep` PID 1 that cannot
-#           receive it; an accepted stop completes daemon-side even if the
-#           client is later SIGKILLed).  The SIGKILL truncation itself is
-#           not directly testable (a SIGKILLed bash leaves no state to
+#        -> s4/s5: cleanup's FIRST container operation of ANY kind is the
+#           quiesce `stop -t 0` -- ahead even of the bundle `exec rm`,
+#           which needs the client to survive the round-trip and could
+#           spend the whole window (no 10s grace for a `sleep` PID 1 that
+#           cannot receive it; an accepted stop completes daemon-side even
+#           if the client is later SIGKILLed).  The events file does not
+#           record the bundle rm, so this ordering is asserted from the
+#           complete calls.log.  The SIGKILL truncation itself is not
+#           directly testable (a SIGKILLed bash leaves no state to
 #           assert), so the mitigation is structural: ordering + timeout
 #           are asserted here, and the next-run self-heal is C8.
 #   C6 container restart fails after the quiesce stop
@@ -54,6 +60,14 @@
 #           <owner> /workspace/dumps` (argument shape asserted in s1), so
 #           the next successful run of the same output folder self-heals
 #           anything a killed cleanup left behind
+#   C9 the quiesce stop FAILS while the container keeps running.  `start`
+#      on an already-running container returns 0 (real-Docker semantics,
+#      observed in review on 29.6.2), so it cannot stand in as a
+#      stopped-state check
+#        -> s8: a failed first stop gates the whole restoration -- no
+#           `start`, no chown against the live writer, warning only --
+#           and the teardown stop (the fake fails only the first) still
+#           kills the writer; the stranded files are C8's self-heal
 #   Out of scope (documented follow-up, per review agreement): root-owned
 #   files written after the restoration point by task `process_command`
 #   background services or by the eval phase; both are the same family
@@ -160,7 +174,8 @@ run_runner() {
 }
 
 start_runner_own_pgroup() {
-    # $1 (optional) container-start behavior for the fake runtime.
+    # $1 (optional) container-start behavior, $2 (optional) container-stop
+    # behavior for the fake runtime.
     # Launch the runner as its own process-group leader so a signal can be
     # delivered to the whole group, mirroring Ctrl-C / an orchestrator kill.
     # A non-job-control shell starts async children with SIGINT/SIGQUIT
@@ -174,6 +189,7 @@ start_runner_own_pgroup() {
         FAKE_PREPROCESS_BEHAVIOR="hang" \
         FAKE_CHOWN_BEHAVIOR="succeed" \
         FAKE_START_BEHAVIOR="${1:-succeed}" \
+        FAKE_STOP_BEHAVIOR="${2:-succeed}" \
         FAKE_DUMPS_OWNER="1000:1000" \
         perl -e '$SIG{INT} = "DEFAULT"; $SIG{QUIT} = "DEFAULT"; setpgrp(0, 0); exec @ARGV; die "exec failed: $!"' \
         "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1 &
@@ -277,6 +293,43 @@ assert_last_event_order() {
     fi
 }
 
+assert_call_before_last() {
+    # $1 label, $2 fixed string whose FIRST calls.log occurrence must
+    # precede the LAST occurrence of fixed string $3.  calls.log sees every
+    # runtime invocation, including execs the events file never records
+    # (C5: cleanup's bundle rm); last-occurrence matching sidesteps the
+    # fake mktemp always returning the same bundle path, so earlier
+    # main-flow rms of that path cannot satisfy the assertion.
+    local first last
+    first=$(grep -nF -- "$2" "$STATE/calls.log" 2>/dev/null |
+        head -n 1 | cut -d: -f1)
+    last=$(grep -nF -- "$3" "$STATE/calls.log" 2>/dev/null |
+        tail -n 1 | cut -d: -f1)
+    if [ -n "$first" ] && [ -n "$last" ] && [ "$first" -lt "$last" ]; then
+        pass "$1"
+    else
+        fail "$1 (calls.log lines: first '$2'=${first:-absent}, last '$3'=${last:-absent}; see $SCENARIO_DIR)"
+    fi
+}
+
+assert_cleanup_opens_with_stop() {
+    # $1 label.  In the interrupted scenarios the hung preprocess exec is
+    # the last main-flow runtime invocation, so the very next call in
+    # calls.log is cleanup's first container operation.  Per C5 it must be
+    # the quiesce `stop -t 0`: not the bundle rm, not any other exec --
+    # nothing that needs a live client may spend the SIGKILL window before
+    # the stop has been submitted.
+    local pre next
+    pre=$(grep -n "container_preprocess" "$STATE/calls.log" 2>/dev/null |
+        tail -n 1 | cut -d: -f1)
+    next=""
+    [ -n "$pre" ] && next=$(sed -n "$((pre + 1))p" "$STATE/calls.log")
+    case "$next" in
+        *" stop -t 0 "*) pass "$1" ;;
+        *) fail "$1 (call after preprocess: '${next:-absent}'; see $SCENARIO_DIR)" ;;
+    esac
+}
+
 # ---------------------------------------------------------------------------
 # C1: preprocess fails but its exec client RETURNS, so the container-side
 # process is already gone -- the main flow restores ownership directly and
@@ -374,6 +427,11 @@ signal_scenario() {
         "SIG$sig: writer survives the signal; quiesce precedes restoration" \
         "preprocess-start" "inner-write" "stop-writer-alive" "stop -t 0" \
         "start" "chown -R -- 1000:1000 /workspace/dumps" "stop"
+    assert_call_before_last \
+        "SIG$sig: the quiesce stop is submitted before cleanup's bundle rm" \
+        "stop -t 0" "rm -f -- /run/fake-decoupled-bundle.json"
+    assert_cleanup_opens_with_stop \
+        "SIG$sig: cleanup's first container operation is the quiesce stop"
     assert_last_event_order \
         "SIG$sig: nothing is written after the restoration" \
         "inner-write" "chown -R -- "
@@ -425,6 +483,11 @@ else
         "143" "$s6_exit"
     assert_event_subsequence "s6: quiesce still happens before the failed restart" \
         "stop-writer-alive" "stop -t 0" "start"
+    assert_call_before_last \
+        "s6: the quiesce stop is submitted before cleanup's bundle rm" \
+        "stop -t 0" "rm -f -- /run/fake-decoupled-bundle.json"
+    assert_cleanup_opens_with_stop \
+        "s6: cleanup's first container operation is the quiesce stop"
     assert_no_event "s6: no restoration without a running container" \
         "chown -R -- "
     assert_log_contains "s6: the failure is reported as a warning" \
@@ -452,6 +515,60 @@ assert_eq "s7: exactly one restoration (the main-flow hand-off)" \
 assert_no_event "s7: cleanup's pending path is not entered" "start"
 assert_event_order "s7: hand-off precedes the final stop" \
     "chown -R -- " "stop"
+
+# ---------------------------------------------------------------------------
+# C9: the quiescing stop itself FAILS while the writer keeps running.  Real
+# `docker start` returns 0 on an already-running container, so the failed
+# stop is the runner's only signal -- it must gate the whole restoration:
+# no restart, no chown into a live writer, warning only.  The fake fails
+# just the first stop, so the teardown stop still kills the writer
+# (`stop-writer-alive` at the SECOND stop proves it was alive the whole
+# time chown could have run) and the container still comes down.
+note "scenario 8: failed quiesce stop skips restoration, writer never chowned"
+new_workdir
+start_runner_own_pgroup succeed fail-once
+if ! wait_for_file "$STATE/preprocess_started" 300; then
+    fail "s8: runner never reached preprocess (see $SCENARIO_DIR)"
+    kill -KILL -- "-$RUNNER_PID" 2>/dev/null
+    wait "$RUNNER_PID" 2>/dev/null
+else
+    sleep 0.5
+    kill -TERM -- "-$RUNNER_PID" 2>/dev/null
+    ( sleep 15 && kill -KILL -- "-$RUNNER_PID" ) >/dev/null 2>&1 &
+    s8_watchdog=$!
+    wait "$RUNNER_PID" 2>/dev/null
+    s8_exit=$?
+    kill "$s8_watchdog" 2>/dev/null
+    wait "$s8_watchdog" 2>/dev/null
+    assert_eq "s8: interruption exit code survives the failed stop" \
+        "143" "$s8_exit"
+    assert_no_event "s8: no chown while the writer may still be running" \
+        "chown -R -- "
+    assert_no_event "s8: no restart after a failed quiesce stop" "start"
+    assert_eq "s8: exactly one stop failure (the quiesce attempt)" \
+        "1" "$(count_events "stop-fail")"
+    assert_event_subsequence \
+        "s8: the writer outlives the failed stop, dies at the teardown stop" \
+        "preprocess-start" "inner-write" "stop-fail" "stop-writer-alive" \
+        "stop -t 0"
+    assert_log_contains "s8: the skipped restoration is reported as a warning" \
+        "Warning: could not restore output ownership"
+    assert_call_before_last \
+        "s8: the quiesce stop is submitted before cleanup's bundle rm" \
+        "stop -t 0" "rm -f -- /run/fake-decoupled-bundle.json"
+    assert_cleanup_opens_with_stop \
+        "s8: cleanup's first container operation is the quiesce stop"
+    if [ ! -e "$STATE/running" ]; then
+        pass "s8: container was stopped by the teardown retry"
+    else
+        fail "s8: container still running after cleanup (see $SCENARIO_DIR)"
+    fi
+    if [ ! -e "$STATE/created" ]; then
+        pass "s8: container was removed"
+    else
+        fail "s8: container still present after cleanup (see $SCENARIO_DIR)"
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/decoupled/test_ownership_restore.sh
+++ b/tests/decoupled/test_ownership_restore.sh
@@ -7,14 +7,58 @@
 # pre-preprocess owner:
 #   1. even when preprocess fails,
 #   2. without clobbering the preprocess exit code,
-#   3. through a best-effort retry in cleanup() before the container is
-#      stopped, which also covers SIGINT/SIGTERM interruptions.
+#   3. through a best-effort pass in cleanup() that first QUIESCES any
+#      container-side writer (killing the local `docker exec` client does
+#      not kill the exec'd process inside the container), then restarts the
+#      inert container and restores ownership -- covering SIGINT/SIGTERM.
 #
 # The container runtime (docker/podman) and the host-side `uv` probes are
 # replaced with fakes from tests/decoupled/fake_bin; no real containers are
 # involved.  The fakes record the commands the runner issues, and the tests
-# assert on that recorded sequence (preprocess -> chown -> stop) plus the
-# runner's exit code.
+# assert on that recorded event sequence plus the runner's exit code.  See
+# fake_bin/docker for the client/container signal-semantics model.
+#
+# Corner-case -> coverage map:
+#   C1 preprocess fails, exec client returns normally
+#        -> s1 (restored via the main flow; cleanup's pending path must NOT
+#           re-enter: no `start` event)
+#   C2 restoration fails after a failed preprocess
+#        -> s2 (warning only; preprocess exit code preserved; cleanup
+#           retries through the quiesced stop -> start -> chown path)
+#   C3 restoration fails after a successful preprocess
+#        -> s3 (fatal: the host agent may not run on root-owned output)
+#   C4 group-delivered SIGTERM/SIGINT kills the exec client while the
+#      container-side process keeps writing (the reviewer's race; produced
+#      in production by run_parallel.py's killpg on task timeout)
+#        -> s4/s5: `stop-writer-alive` proves the writer survived the
+#           group signal; first `stop` precedes the cleanup chown
+#           (quiesce-before-restore); `start` sits between them; the last
+#           `inner-write` precedes the cleanup chown (the race is closed)
+#   C5 run_parallel.py escalates SIGTERM to SIGKILL after only 3 seconds
+#        -> s4/s5: the pending path's FIRST container action is `stop`
+#           with `-t 0` (no 10s grace for a `sleep` PID 1 that cannot
+#           receive it; an accepted stop completes daemon-side even if the
+#           client is later SIGKILLed).  The SIGKILL truncation itself is
+#           not directly testable (a SIGKILLed bash leaves no state to
+#           assert), so the mitigation is structural: ordering + timeout
+#           are asserted here, and the next-run self-heal is C8.
+#   C6 container restart fails after the quiesce stop
+#        -> s6 (warning only; container still stopped and removed; the
+#           interruption exit code is preserved)
+#   C7 successful hand-off (the healthy path)
+#        -> s7 (exactly one chown -- the main-flow hand-off -- and the
+#           pending path is never entered: no `start` event)
+#   C8 SIGKILL / double-Ctrl-C strands root-owned files with no cleanup
+#        -> not directly testable (no process left to observe); bounded by
+#           design: the restoration is always a full-tree `chown -R
+#           <owner> /workspace/dumps` (argument shape asserted in s1), so
+#           the next successful run of the same output folder self-heals
+#           anything a killed cleanup left behind
+#   Out of scope (documented follow-up, per review agreement): root-owned
+#   files written after the restoration point by task `process_command`
+#   background services or by the eval phase; both are the same family
+#   ("container-side root writers that outlive the hand-off") and need a
+#   separate end-of-run restoration pass.
 #
 # Requirements: Linux or any GNU userland (the runner itself depends on GNU
 # `readlink -f` semantics).  Run from anywhere:
@@ -46,6 +90,14 @@ note() {
 }
 
 on_exit() {
+    # A failed scenario may leave a detached inner writer running (it is
+    # normally killed by the fake `stop`); reap it so nothing outlives the
+    # test run.
+    for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
+        if [ -f "$dir/state/inner_writer_pid" ]; then
+            kill -9 "$(cat "$dir/state/inner_writer_pid")" 2>/dev/null
+        fi
+    done
     if [ "$FAIL_COUNT" -eq 0 ] && [ "${KEEP_TEST_ARTIFACTS:-0}" != "1" ]; then
         for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
             rm -rf -- "$dir"
@@ -108,6 +160,7 @@ run_runner() {
 }
 
 start_runner_own_pgroup() {
+    # $1 (optional) container-start behavior for the fake runtime.
     # Launch the runner as its own process-group leader so a signal can be
     # delivered to the whole group, mirroring Ctrl-C / an orchestrator kill.
     # A non-job-control shell starts async children with SIGINT/SIGQUIT
@@ -120,6 +173,7 @@ start_runner_own_pgroup() {
         FAKE_RUNTIME_STATE="$STATE" \
         FAKE_PREPROCESS_BEHAVIOR="hang" \
         FAKE_CHOWN_BEHAVIOR="succeed" \
+        FAKE_START_BEHAVIOR="${1:-succeed}" \
         FAKE_DUMPS_OWNER="1000:1000" \
         perl -e '$SIG{INT} = "DEFAULT"; $SIG{QUIT} = "DEFAULT"; setpgrp(0, 0); exec @ARGV; die "exec failed: $!"' \
         "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1 &
@@ -149,6 +203,36 @@ event_last_lineno() {
 
 count_events() {
     grep -c "^$1" "$STATE/events" 2>/dev/null || true
+}
+
+assert_event_subsequence() {
+    # $1 label; remaining args are event prefixes that must appear in the
+    # events file in the given order (as a subsequence: other events may be
+    # interleaved).  Prefix matching is literal, no regex.
+    local label=$1; shift
+    local lineno=0 prefix next
+    for prefix in "$@"; do
+        next=$(awk -v start="$lineno" -v pat="$prefix" \
+            'NR > start && index($0, pat) == 1 {print NR; exit}' \
+            "$STATE/events" 2>/dev/null)
+        if [ -z "$next" ]; then
+            fail "$label (no '$prefix' after line $lineno; see $SCENARIO_DIR)"
+            return
+        fi
+        lineno=$next
+    done
+    pass "$label"
+}
+
+assert_no_event() {
+    # $1 label, $2 event prefix that must not appear
+    local n
+    n=$(count_events "$2")
+    if [ "${n:-0}" -eq 0 ]; then
+        pass "$1"
+    else
+        fail "$1 ('$2' appeared $n time(s); see $SCENARIO_DIR)"
+    fi
 }
 
 assert_eq() {
@@ -194,6 +278,12 @@ assert_last_event_order() {
 }
 
 # ---------------------------------------------------------------------------
+# C1: preprocess fails but its exec client RETURNS, so the container-side
+# process is already gone -- the main flow restores ownership directly and
+# cleanup's pending path (quiesce + restart) must not re-enter.  The
+# full-tree `chown -R <owner> /workspace/dumps` argument shape asserted here
+# is also the C8 self-heal: it is what collects files stranded by an
+# unkillable-cleanup (SIGKILL) on the next successful run.
 note "scenario 1: preprocess failure still restores ownership"
 new_workdir
 run_runner "fail:7" "succeed" "4242:4242"
@@ -203,12 +293,17 @@ assert_event_order "s1: ownership restored after preprocess" \
     "preprocess-start" "chown -R -- "
 assert_event_order "s1: ownership restored before container stop" \
     "chown -R -- " "stop"
-assert_eq "s1: restoration uses the captured owner" \
+assert_eq "s1: restoration is a full-tree pass with the captured owner" \
     "1" "$(count_events "chown -R -- 4242:4242 /workspace/dumps")"
 assert_eq "s1: restoration is not repeated by cleanup" \
     "1" "$(count_events "chown -R -- ")"
+assert_no_event "s1: cleanup's pending path is not entered" "start"
 
 # ---------------------------------------------------------------------------
+# C2: the main-flow restoration itself fails after a failed preprocess.  The
+# preprocess exit code stays authoritative and cleanup retries -- through the
+# quiesced path (stop first, then restart, then chown), since after any
+# abnormal flow a container-side writer cannot be ruled out.
 note "scenario 2: failed restoration cannot mask the preprocess exit code"
 new_workdir
 run_runner "fail:7" "fail" "1000:1000"
@@ -217,10 +312,13 @@ assert_log_contains "s2: restoration failure is only a warning" \
     "Warning: could not restore output ownership after failed preprocess"
 assert_eq "s2: cleanup retries the pending restoration" \
     "2" "$(count_events "chown -R -- ")"
-assert_last_event_order "s2: the cleanup retry happens before container stop" \
-    "chown -R -- " "stop"
+assert_event_subsequence "s2: the cleanup retry goes through the quiesced path" \
+    "preprocess-start" "chown -R -- " "stop -t 0" "start" "chown -R -- " "stop"
 
 # ---------------------------------------------------------------------------
+# C3: restoration fails after a SUCCESSFUL preprocess -- fatal, because the
+# host agent must never run against root-owned output.  Cleanup still makes
+# its best-effort quiesced retry.
 note "scenario 3: successful preprocess still fails hard on a failed chown"
 new_workdir
 run_runner "succeed" "fail" "1000:1000"
@@ -230,18 +328,27 @@ assert_log_contains "s3: hand-off failure is reported" \
     "Failed to hand output ownership to the host agent"
 assert_eq "s3: cleanup still retries the pending restoration" \
     "2" "$(count_events "chown -R -- ")"
+assert_event_subsequence "s3: the cleanup retry is quiesced too" \
+    "chown -R -- " "stop -t 0" "start" "chown -R -- "
 
 # ---------------------------------------------------------------------------
-# Interruption coverage.  A group-delivered fatal signal kills the hung
-# preprocess exec and makes the runner abort through its EXIT trap, so the
-# restoration must come from cleanup()'s pending path — for SIGTERM and
-# SIGINT alike.  Each scenario asserts the signal's conventional 128+N exit
-# code (a 137 here means the watchdog had to SIGKILL a runner that ignored
-# the signal), and that ownership is restored exactly once, before the
-# container is stopped.
+# C4 + C5 (s4 SIGTERM / s5 SIGINT).  A group-delivered fatal signal kills
+# the local exec CLIENT, but the container-side process survives it and
+# keeps writing (`inner-write` events) until the container is torn down —
+# the exact race observed in review on rootful Docker, and what
+# run_parallel.py's killpg produces on task timeout.  Cleanup must
+# therefore quiesce first: its pending path's FIRST container action is
+# `stop -t 0` (C5: only a ~3s window exists before the orchestrator's
+# SIGKILL; a `sleep` PID 1 never honors a graceful stop, so any longer
+# timeout is pure loss), then restart the inert container, then chown.
+# `stop-writer-alive` proves the writer outlived the group signal, and the
+# last `inner-write` preceding the restoration proves the race is closed.
+# Each scenario also asserts the signal's conventional 128+N exit code (a
+# 137 here means the watchdog had to SIGKILL a runner that ignored the
+# signal).
 signal_scenario() {
     local sig=$1 expected_exit=$2
-    note "scenario SIG$sig: interruption still restores ownership"
+    note "scenario SIG$sig: interruption quiesces the writer, then restores"
     new_workdir
     start_runner_own_pgroup
     if ! wait_for_file "$STATE/preprocess_started" 300; then
@@ -263,21 +370,88 @@ signal_scenario() {
     wait "$watchdog" 2>/dev/null
     assert_eq "SIG$sig: runner exits with the signal's status" \
         "$expected_exit" "$observed_exit"
-    assert_event_order "SIG$sig: ownership restored after interruption" \
-        "preprocess-start" "chown -R -- "
-    assert_event_order "SIG$sig: restoration happens before container stop" \
-        "chown -R -- " "stop"
+    assert_event_subsequence \
+        "SIG$sig: writer survives the signal; quiesce precedes restoration" \
+        "preprocess-start" "inner-write" "stop-writer-alive" "stop -t 0" \
+        "start" "chown -R -- 1000:1000 /workspace/dumps" "stop"
+    assert_last_event_order \
+        "SIG$sig: nothing is written after the restoration" \
+        "inner-write" "chown -R -- "
     assert_eq "SIG$sig: exactly one restoration attempt" \
         "1" "$(count_events "chown -R -- ")"
+    assert_eq "SIG$sig: the writer is dead by the second (final) stop" \
+        "1" "$(count_events "stop-writer-alive")"
+    assert_eq "SIG$sig: the container is restarted exactly once" \
+        "1" "$(count_events "start")"
     if [ ! -e "$STATE/running" ]; then
         pass "SIG$sig: container was stopped by cleanup"
     else
         fail "SIG$sig: container still running after cleanup (see $SCENARIO_DIR)"
     fi
+    if [ ! -e "$STATE/created" ]; then
+        pass "SIG$sig: container was removed by cleanup"
+    else
+        fail "SIG$sig: container still present after cleanup (see $SCENARIO_DIR)"
+    fi
 }
 
 signal_scenario TERM 143
 signal_scenario INT 130
+
+# ---------------------------------------------------------------------------
+# C6: the restart after the quiesce stop fails.  Restoration is best-effort
+# on this path — the runner must warn, keep the interruption exit code, and
+# still stop/remove the container.  No chown can happen (the container
+# never came back), so the stranded files are left for the next successful
+# run's full-tree hand-off (C8) — but the writer is still dead, which is
+# the part that must never fail.
+note "scenario 6: failed restart degrades to a warning, writer still dead"
+new_workdir
+start_runner_own_pgroup fail
+if ! wait_for_file "$STATE/preprocess_started" 300; then
+    fail "s6: runner never reached preprocess (see $SCENARIO_DIR)"
+    kill -KILL -- "-$RUNNER_PID" 2>/dev/null
+    wait "$RUNNER_PID" 2>/dev/null
+else
+    sleep 0.5
+    kill -TERM -- "-$RUNNER_PID" 2>/dev/null
+    ( sleep 15 && kill -KILL -- "-$RUNNER_PID" ) >/dev/null 2>&1 &
+    s6_watchdog=$!
+    wait "$RUNNER_PID" 2>/dev/null
+    s6_exit=$?
+    kill "$s6_watchdog" 2>/dev/null
+    wait "$s6_watchdog" 2>/dev/null
+    assert_eq "s6: interruption exit code survives the failed restart" \
+        "143" "$s6_exit"
+    assert_event_subsequence "s6: quiesce still happens before the failed restart" \
+        "stop-writer-alive" "stop -t 0" "start"
+    assert_no_event "s6: no restoration without a running container" \
+        "chown -R -- "
+    assert_log_contains "s6: the failure is reported as a warning" \
+        "Warning: could not restore output ownership"
+    if [ ! -e "$STATE/created" ]; then
+        pass "s6: container was still removed"
+    else
+        fail "s6: container still present after cleanup (see $SCENARIO_DIR)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# C7: successful hand-off.  The main flow restores ownership exactly once
+# and clears the pending flag, so cleanup's quiesce/restart path must never
+# run — the fix may not tax the healthy path.  The fake `docker cp` does
+# not materialize the bundle file, so the runner exits at the `chmod 600`
+# guard right AFTER the hand-off — the exact moment cleanup's non-pending
+# behavior is observable, without mocking the whole agent/eval pipeline.
+note "scenario 7: successful hand-off never re-enters the pending path"
+new_workdir
+run_runner "succeed" "succeed" "1000:1000"
+assert_log_contains "s7: the hand-off path completed" "Preprocess completed"
+assert_eq "s7: exactly one restoration (the main-flow hand-off)" \
+    "1" "$(count_events "chown -R -- ")"
+assert_no_event "s7: cleanup's pending path is not entered" "start"
+assert_event_order "s7: hand-off precedes the final stop" \
+    "chown -R -- " "stop"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/decoupled/test_ownership_restore.sh
+++ b/tests/decoupled/test_ownership_restore.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Regression tests for the ownership-restoration flow in
+# scripts/run_single_decoupled.sh.
+#
+# Preprocess runs as container root and writes into the bind-mounted output
+# tree (/workspace/dumps).  The runner must hand ownership back to the
+# pre-preprocess owner:
+#   1. even when preprocess fails,
+#   2. without clobbering the preprocess exit code,
+#   3. through a best-effort retry in cleanup() before the container is
+#      stopped, which also covers SIGINT/SIGTERM interruptions.
+#
+# The container runtime (docker/podman) and the host-side `uv` probes are
+# replaced with fakes from tests/decoupled/fake_bin; no real containers are
+# involved.  The fakes record the commands the runner issues, and the tests
+# assert on that recorded sequence (preprocess -> chown -> stop) plus the
+# runner's exit code.
+#
+# Requirements: Linux or any GNU userland (the runner itself depends on GNU
+# `readlink -f` semantics).  Run from anywhere:
+#   bash tests/decoupled/test_ownership_restore.sh
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/../.." && pwd)"
+RUNNER="$REPO_ROOT/scripts/run_single_decoupled.sh"
+FAKE_BIN="$TESTS_DIR/fake_bin"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+KEEP_DIRS=()
+
+pass() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "ok - $1"
+}
+
+fail() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "not ok - $1"
+}
+
+note() {
+    echo "# $*"
+}
+
+on_exit() {
+    if [ "$FAIL_COUNT" -eq 0 ] && [ "${KEEP_TEST_ARTIFACTS:-0}" != "1" ]; then
+        for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
+            rm -rf -- "$dir"
+        done
+    else
+        for dir in ${KEEP_DIRS[@]+"${KEEP_DIRS[@]}"}; do
+            note "artifacts kept in $dir"
+        done
+    fi
+}
+trap on_exit EXIT
+
+if [ ! -f "$RUNNER" ]; then
+    echo "runner not found: $RUNNER" >&2
+    exit 1
+fi
+
+# Any real task directory satisfies the runner's existence check; the fake
+# runtime never copies it anywhere.
+TASK_DIR_REL=$(
+    cd "$REPO_ROOT/tasks" 2>/dev/null &&
+    find . -mindepth 2 -maxdepth 2 -type d |
+    sed 's|^\./||' |
+    grep -E '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$' |
+    LC_ALL=C sort |
+    head -n 1
+)
+if [ -z "$TASK_DIR_REL" ]; then
+    echo "no task directory found under $REPO_ROOT/tasks" >&2
+    exit 1
+fi
+note "using task directory: $TASK_DIR_REL"
+
+new_workdir() {
+    SCENARIO_DIR=$(mktemp -d "${TMPDIR:-/tmp}/toolathlon-ownership-test.XXXXXX")
+    KEEP_DIRS+=("$SCENARIO_DIR")
+    STATE="$SCENARIO_DIR/state"
+    DUMPS="$SCENARIO_DIR/dumps"
+    mkdir -p "$STATE" "$DUMPS"
+}
+
+build_runner_cmd() {
+    # Positional gateway_port avoids the runner's live-socket probe.
+    RUNNER_CMD=(
+        bash "$RUNNER" "$TASK_DIR_REL" normal "$DUMPS" fake-model unified 5
+        scripts/formal_run_v0.json fake-image toolathlon_default 18999
+    )
+}
+
+run_runner() {
+    # $1 preprocess behavior, $2 chown behavior, $3 reported dumps owner
+    build_runner_cmd
+    env PATH="$FAKE_BIN:$PATH" \
+        FAKE_RUNTIME_STATE="$STATE" \
+        FAKE_PREPROCESS_BEHAVIOR="$1" \
+        FAKE_CHOWN_BEHAVIOR="$2" \
+        FAKE_DUMPS_OWNER="$3" \
+        "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1
+    RUNNER_EXIT=$?
+}
+
+start_runner_own_pgroup() {
+    # Launch the runner as its own process-group leader so a signal can be
+    # delivered to the whole group, mirroring Ctrl-C / an orchestrator kill.
+    # A non-job-control shell starts async children with SIGINT/SIGQUIT
+    # ignored, the ignore survives both exec and setsid, and an ignored
+    # signal would make kill -INT a silent no-op (the scenario would then
+    # pass vacuously once the fake's hang expires).  The perl wrapper
+    # restores the default dispositions before entering the new group.
+    build_runner_cmd
+    env PATH="$FAKE_BIN:$PATH" \
+        FAKE_RUNTIME_STATE="$STATE" \
+        FAKE_PREPROCESS_BEHAVIOR="hang" \
+        FAKE_CHOWN_BEHAVIOR="succeed" \
+        FAKE_DUMPS_OWNER="1000:1000" \
+        perl -e '$SIG{INT} = "DEFAULT"; $SIG{QUIT} = "DEFAULT"; setpgrp(0, 0); exec @ARGV; die "exec failed: $!"' \
+        "${RUNNER_CMD[@]}" > "$STATE/runner.log" 2>&1 &
+    RUNNER_PID=$!
+}
+
+wait_for_file() {
+    # $1 path, $2 max iterations of 0.2s
+    local i=0
+    while [ "$i" -lt "$2" ]; do
+        [ -e "$1" ] && return 0
+        sleep 0.2
+        i=$((i + 1))
+    done
+    return 1
+}
+
+event_lineno() {
+    # First line number in the events file matching prefix $1; empty if none.
+    grep -n "^$1" "$STATE/events" 2>/dev/null | head -n 1 | cut -d: -f1
+}
+
+event_last_lineno() {
+    # Last line number in the events file matching prefix $1; empty if none.
+    grep -n "^$1" "$STATE/events" 2>/dev/null | tail -n 1 | cut -d: -f1
+}
+
+count_events() {
+    grep -c "^$1" "$STATE/events" 2>/dev/null || true
+}
+
+assert_eq() {
+    # $1 label, $2 expected, $3 actual
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1 (expected '$2', got '$3'; see $SCENARIO_DIR)"
+    fi
+}
+
+assert_log_contains() {
+    # $1 label, $2 fixed string expected in runner.log
+    if grep -qF "$2" "$STATE/runner.log"; then
+        pass "$1"
+    else
+        fail "$1 (missing '$2' in $STATE/runner.log)"
+    fi
+}
+
+assert_event_order() {
+    # $1 label, $2 earlier event prefix, $3 later event prefix
+    local earlier later
+    earlier=$(event_lineno "$2")
+    later=$(event_lineno "$3")
+    if [ -n "$earlier" ] && [ -n "$later" ] && [ "$earlier" -lt "$later" ]; then
+        pass "$1"
+    else
+        fail "$1 (lines: '$2'=${earlier:-absent}, '$3'=${later:-absent}; see $SCENARIO_DIR)"
+    fi
+}
+
+assert_last_event_order() {
+    # Like assert_event_order, but pins the LAST occurrence of $2 before $3.
+    local earlier later
+    earlier=$(event_last_lineno "$2")
+    later=$(event_lineno "$3")
+    if [ -n "$earlier" ] && [ -n "$later" ] && [ "$earlier" -lt "$later" ]; then
+        pass "$1"
+    else
+        fail "$1 (lines: last '$2'=${earlier:-absent}, '$3'=${later:-absent}; see $SCENARIO_DIR)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+note "scenario 1: preprocess failure still restores ownership"
+new_workdir
+run_runner "fail:7" "succeed" "4242:4242"
+assert_eq "s1: preprocess exit code is preserved" "7" "$RUNNER_EXIT"
+assert_log_contains "s1: failure is reported" "Preprocess failed, exit code: 7"
+assert_event_order "s1: ownership restored after preprocess" \
+    "preprocess-start" "chown -R -- "
+assert_event_order "s1: ownership restored before container stop" \
+    "chown -R -- " "stop"
+assert_eq "s1: restoration uses the captured owner" \
+    "1" "$(count_events "chown -R -- 4242:4242 /workspace/dumps")"
+assert_eq "s1: restoration is not repeated by cleanup" \
+    "1" "$(count_events "chown -R -- ")"
+
+# ---------------------------------------------------------------------------
+note "scenario 2: failed restoration cannot mask the preprocess exit code"
+new_workdir
+run_runner "fail:7" "fail" "1000:1000"
+assert_eq "s2: preprocess exit code survives a failed chown" "7" "$RUNNER_EXIT"
+assert_log_contains "s2: restoration failure is only a warning" \
+    "Warning: could not restore output ownership after failed preprocess"
+assert_eq "s2: cleanup retries the pending restoration" \
+    "2" "$(count_events "chown -R -- ")"
+assert_last_event_order "s2: the cleanup retry happens before container stop" \
+    "chown -R -- " "stop"
+
+# ---------------------------------------------------------------------------
+note "scenario 3: successful preprocess still fails hard on a failed chown"
+new_workdir
+run_runner "succeed" "fail" "1000:1000"
+assert_eq "s3: failed hand-off after successful preprocess is fatal" \
+    "1" "$RUNNER_EXIT"
+assert_log_contains "s3: hand-off failure is reported" \
+    "Failed to hand output ownership to the host agent"
+assert_eq "s3: cleanup still retries the pending restoration" \
+    "2" "$(count_events "chown -R -- ")"
+
+# ---------------------------------------------------------------------------
+# Interruption coverage.  A group-delivered fatal signal kills the hung
+# preprocess exec and makes the runner abort through its EXIT trap, so the
+# restoration must come from cleanup()'s pending path — for SIGTERM and
+# SIGINT alike.  Each scenario asserts the signal's conventional 128+N exit
+# code (a 137 here means the watchdog had to SIGKILL a runner that ignored
+# the signal), and that ownership is restored exactly once, before the
+# container is stopped.
+signal_scenario() {
+    local sig=$1 expected_exit=$2
+    note "scenario SIG$sig: interruption still restores ownership"
+    new_workdir
+    start_runner_own_pgroup
+    if ! wait_for_file "$STATE/preprocess_started" 300; then
+        fail "SIG$sig: runner never reached preprocess (see $SCENARIO_DIR)"
+        kill -KILL -- "-$RUNNER_PID" 2>/dev/null
+        wait "$RUNNER_PID" 2>/dev/null
+        return
+    fi
+    sleep 0.5  # let the runner block inside the hung preprocess exec
+    kill "-$sig" -- "-$RUNNER_PID" 2>/dev/null
+    # Bound the wait: if the signal were ever ignored again, the watchdog
+    # SIGKILLs the group, wait returns 137, and the exit-code assertion
+    # fails fast instead of riding out the fake's hang.
+    ( sleep 15 && kill -KILL -- "-$RUNNER_PID" ) >/dev/null 2>&1 &
+    local watchdog=$!
+    wait "$RUNNER_PID" 2>/dev/null
+    local observed_exit=$?
+    kill "$watchdog" 2>/dev/null
+    wait "$watchdog" 2>/dev/null
+    assert_eq "SIG$sig: runner exits with the signal's status" \
+        "$expected_exit" "$observed_exit"
+    assert_event_order "SIG$sig: ownership restored after interruption" \
+        "preprocess-start" "chown -R -- "
+    assert_event_order "SIG$sig: restoration happens before container stop" \
+        "chown -R -- " "stop"
+    assert_eq "SIG$sig: exactly one restoration attempt" \
+        "1" "$(count_events "chown -R -- ")"
+    if [ ! -e "$STATE/running" ]; then
+        pass "SIG$sig: container was stopped by cleanup"
+    else
+        fail "SIG$sig: container still running after cleanup (see $SCENARIO_DIR)"
+    fi
+}
+
+signal_scenario TERM 143
+signal_scenario INT 130
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "passed: $PASS_COUNT, failed: $FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/utils/api_model/model_provider.py
+++ b/utils/api_model/model_provider.py
@@ -868,6 +868,7 @@ class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
                         'maximum prompt length is', # for xAI model
                         'request exceeded model token limit', # for kimi
                         'exceed max message tokens', # for seed
+                        "exceeds the model's context window",
                         'is longer than'
                     ]):
                         context_too_long = True
@@ -897,6 +898,18 @@ class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
                         match = re.search(r'request exceeded model token limit: (\d+)', error_str)
                         if match:
                             max_tokens = int(match.group(1))
+
+                        # Pattern 6: "Prompt length plus max_tokens exceeds the
+                        # model's context window: 266350 prompt tokens + 256000
+                        # max_tokens > 262144."
+                        match = re.search(
+                            r"(\d+) prompt tokens \+ (\d+) max_tokens > (\d+)",
+                            error_str,
+                            re.IGNORECASE,
+                        )
+                        if match:
+                            prompt_tokens, requested_output_tokens, max_tokens = map(int, match.groups())
+                            current_tokens = prompt_tokens + requested_output_tokens
                 
                 # 2. Try parsing structured error (OpenAI API error object)
                 if hasattr(e, 'response') and hasattr(e.response, 'json'):
@@ -921,6 +934,7 @@ class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
                             'maximum prompt length is', # for xAI model
                             'request exceeded model token limit', # for kimi
                             'exceed max message tokens', # for seed
+                            "exceeds the model's context window",
                             'is longer than'
                         ]) or error_code in ['string_above_max_length', 'context_length_exceeded', 'messages_too_long']:
                             context_too_long = True
@@ -945,6 +959,7 @@ class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
                         'maximum prompt length is', # for xAI model
                         'request exceeded model token limit', # for kimi
                         'exceed max message tokens', # for seed
+                        "exceeds the model's context window",
                         'is longer than'
                     ]):
                         context_too_long = True
@@ -1023,6 +1038,7 @@ class OpenAIResponsesModelWithRetry(OpenAIResponsesModel):
                     if any(pattern in lower_error for pattern in [
                         'maximum context length is',
                         'exceeds the context window',
+                        "exceeds the model's context window",
                         # Some OpenAI-Responses-compatible endpoints do not emit an
                         # explicit context-length message. When the (server-side,
                         # stateful) input exceeds the model's context window they
@@ -1041,6 +1057,15 @@ class OpenAIResponsesModelWithRetry(OpenAIResponsesModel):
                         match = re.search(r'maximum context length is (\d+) tokens. however, you requested about (\d+) tokens', error_str)
                         if match:
                             max_tokens, current_tokens = int(match.group(1)), int(match.group(2))
+
+                        match = re.search(
+                            r"(\d+) prompt tokens \+ (\d+) max_tokens > (\d+)",
+                            error_str,
+                            re.IGNORECASE,
+                        )
+                        if match:
+                            prompt_tokens, requested_output_tokens, max_tokens = map(int, match.groups())
+                            current_tokens = prompt_tokens + requested_output_tokens
                 
                 # If context too long detected, do not retry, raise
                 if context_too_long:

--- a/utils/data_structures/agent_config.py
+++ b/utils/data_structures/agent_config.py
@@ -10,11 +10,20 @@ class Tool:
     tool_choice: Union[Literal["auto", "none", "required"], str] = "auto"
     parallel_tool_calls: bool = False
     max_inner_turns: int = 20
-    
+    # When True, MCPServerManager appends a synthetic 'ptc' server exposing
+    # `programmatic_tool_call`, which runs Python code that drives the
+    # underlying MCP tools through a `tools["<server>-<tool>"]` proxy.
+    programmatic_tool_calling: bool = False
+    ptc_timeout_seconds: int = 60
+
     def __post_init__(self):
         """Validate the reasonability of tool call parameters"""
         if self.max_inner_turns < 1:
             raise ValueError(f"max_inner_turns should be greater than 0, but got {self.max_inner_turns}")
+        if self.ptc_timeout_seconds < 1:
+            raise ValueError(
+                f"ptc_timeout_seconds should be >= 1, but got {self.ptc_timeout_seconds}"
+            )
 
 @dataclass
 class AgentConfig:
@@ -79,10 +88,12 @@ class AgentConfig:
                     "tool_choice": self.tool.tool_choice,
                     "parallel_tool_calls": self.tool.parallel_tool_calls,
                     "max_inner_turns": self.tool.max_inner_turns,
+                    "programmatic_tool_calling": self.tool.programmatic_tool_calling,
+                    "ptc_timeout_seconds": self.tool.ptc_timeout_seconds,
                 }
             }
         }
-    
+
     def to_dict_without_agent_key(self) -> dict:
         """Convert to dictionary without agent key"""
         return {
@@ -102,6 +113,8 @@ class AgentConfig:
                 "tool_choice": self.tool.tool_choice,
                 "parallel_tool_calls": self.tool.parallel_tool_calls,
                 "max_inner_turns": self.tool.max_inner_turns,
+                "programmatic_tool_calling": self.tool.programmatic_tool_calling,
+                "ptc_timeout_seconds": self.tool.ptc_timeout_seconds,
             }
         }
     
@@ -162,11 +175,19 @@ def create_agent_config(
     max_tokens: int = 4096,
     tool_choice: str = "auto",
     parallel_tool_calls: bool = False,
-    max_inner_turns: int = 20
+    max_inner_turns: int = 20,
+    programmatic_tool_calling: bool = False,
+    ptc_timeout_seconds: int = 60,
 ) -> AgentConfig:
     """Convenient constructor, using flat parameters"""
     return AgentConfig(
         model=Model(short_name=model_name, provider=provider),
         generation=Generation(temperature=temperature, top_p=top_p, max_tokens=max_tokens),
-        tool=Tool(tool_choice=tool_choice, parallel_tool_calls=parallel_tool_calls, max_inner_turns=max_inner_turns)
+        tool=Tool(
+            tool_choice=tool_choice,
+            parallel_tool_calls=parallel_tool_calls,
+            max_inner_turns=max_inner_turns,
+            programmatic_tool_calling=programmatic_tool_calling,
+            ptc_timeout_seconds=ptc_timeout_seconds,
+        )
     )

--- a/utils/mcp/ptc_wrapper.py
+++ b/utils/mcp/ptc_wrapper.py
@@ -1,0 +1,819 @@
+"""
+Programmatic Tool Calling (PTC) wrapper for Toolathlon.
+
+The model is given one extra tool, ``programmatic_tool_call``, that runs Python
+code in a persistent subprocess sandbox. From inside the sandbox, the code
+calls the task's underlying MCP tools through a ``tools`` proxy, e.g.::
+
+    tools["canvas-list_courses"]()
+    tools["arxiv-search"](query="LLM agents", max_results=5)
+
+The proxy forwards tool calls back to the parent over a JSON-line protocol on
+stdin/stdout; the parent looks the name up in an aggregated index built from
+all connected ``MCPServerManager`` servers and dispatches to the right one.
+Index keys are ``f"{server.name}-{tool.name}"``, matching the prefixed names
+the model already sees through ``custom_mcp_util.my_to_function_tool``.
+
+Design points worth knowing:
+  * Tool failures raise exceptions inside the sandbox, so ``try/except``
+    around a tool call works and error text never flows onward as data.
+  * Values cross the pipe as JSON; anything without a JSON equivalent is
+    reduced to a string (see ``_jsonify``).
+  * Tool results are recovered from the ``CallToolResult`` text payload
+    deterministically, so a given tool always yields the same Python type.
+  * Unknown tool names return ranked "Did you mean: ..." suggestions.
+  * Oversized sandbox output is middle-truncated (env-configurable).
+
+The wrapper ships as a synthetic ``MCPServer`` (``PTCSyntheticServer``) so the
+existing OpenAI-Agents-SDK plumbing picks it up with no further changes.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import datetime as _datetime
+import difflib
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+import uuid
+from decimal import Decimal
+from typing import Any, Dict, List, Optional, Tuple
+
+from agents.mcp import MCPServer
+from mcp.types import CallToolResult, TextContent, Tool as MCPTool
+
+logger = logging.getLogger(__name__)
+
+
+# Cap on the output a single programmatic_tool_call may return (chars). Agents
+# occasionally print entire fetched datasets (hundreds of KB), which poisons
+# the context. 0 disables.
+_MAX_OUTPUT_CHARS = int(os.getenv("TOOLATHLON_PTC_MAX_OUTPUT_CHARS", "10000"))
+
+
+# Persistent worker source. Stays alive across calls; talks JSON-line on
+# stdin/stdout. Kept as a string so we can drop it onto disk lazily.
+_PERSISTENT_WORKER = r'''
+import os, sys, json, csv, traceback, uuid
+from io import StringIO
+from contextlib import redirect_stdout, redirect_stderr
+
+_proto_out = sys.stdout
+_proto_in = sys.stdin
+
+
+def _read_msg():
+    line = _proto_in.readline()
+    if not line:
+        sys.exit(0)
+    return json.loads(line)
+
+
+def _write_msg(msg):
+    # default=str: a tool argument the user's code built out of a non-JSON
+    # type (a Decimal, a datetime) is sent as its string form rather than
+    # raising here — the tool call still goes out, and the receiving tool
+    # reports the type problem if it cares.
+    _proto_out.write(json.dumps(msg, default=str) + "\n")
+    _proto_out.flush()
+
+
+def _rpc_tool_call(tool_name, args, kwargs):
+    req_id = uuid.uuid4().hex
+    _write_msg({"type": "tool_call", "id": req_id,
+                "tool_name": tool_name,
+                "args": list(args),
+                "kwargs": dict(kwargs)})
+    while True:
+        msg = _read_msg()
+        if msg.get("type") == "tool_result" and msg.get("id") == req_id:
+            if msg.get("ok"):
+                return msg.get("value")
+            # Raise (rather than return an error string) so failures surface
+            # as exceptions — try/except around tool calls works and errors
+            # never flow onward disguised as data.
+            raise RuntimeError(msg.get("error", "unknown error"))
+
+
+class _ToolProxy:
+    __slots__ = ("_name",)
+
+    def __init__(self, name):
+        object.__setattr__(self, "_name", name)
+
+    def __call__(self, *args, **kwargs):
+        return _rpc_tool_call(self._name, args, kwargs)
+
+
+class ToolCaller:
+    def __getitem__(self, key):
+        return _ToolProxy(str(key))
+
+    def __getattr__(self, name):
+        return _ToolProxy(str(name))
+
+
+def main():
+    init = _read_msg()
+    workspace = init.get("workspace") or os.getcwd()
+    try:
+        os.chdir(workspace)
+    except Exception:
+        pass
+
+    g = {
+        "__name__": "__main__",
+        "tools": ToolCaller(),
+        "WORKSPACE": workspace,
+        "workspace_path": workspace,
+        # Pre-imports, as promised in the tool description.
+        "os": os,
+        "sys": sys,
+        "json": json,
+        "csv": csv,
+    }
+
+    _write_msg({"type": "ready"})
+
+    while True:
+        try:
+            msg = _read_msg()
+        except Exception as exc:
+            _write_msg({"type": "done", "stdout": None, "stderr": None,
+                        "error": f"Protocol error: {exc}"})
+            continue
+
+        if msg.get("type") != "exec":
+            continue
+
+        code = msg.get("code", "")
+        file_path = msg.get("file_path", "<code>")
+        g["__file__"] = file_path
+
+        out_buf, err_buf, tb = StringIO(), StringIO(), None
+        try:
+            with redirect_stdout(out_buf), redirect_stderr(err_buf):
+                exec(compile(code, file_path, "exec"), g)
+        except Exception:
+            tb = traceback.format_exc()
+
+        _write_msg({"type": "done",
+                    "stdout": out_buf.getvalue() or None,
+                    "stderr": err_buf.getvalue() or None,
+                    "error": tb})
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+# Tool names are prefixed `<server>-<tool>` (hyphens), so only bracket access
+# works — the examples below use it throughout.
+_CODE_EXECUTION_DESCRIPTION = (
+    'Run Python that calls the tools listed above as `tools["tool_name"](*args, **kwargs)`. State (variables, imports) persists across calls. Use print() to see output.\n'
+    "USE WHEN: loops, conditionals, error handling, or chaining multiple tool calls with intermediate processing.\n\n"
+    "Notes:\n"
+    "- Code runs in the workspace directory and file writes are restricted to it, don't write to `/tmp`; always use absolute paths for file writes; os, json, csv, sys are pre-imported.\n"
+    "- Tools return native Python values; the type and structure vary by tool (e.g. dict, list, or str). Always print and inspect the first result before processing many items; do not assume a result is a list and loop over it.\n"
+    "- Very large printed output is truncated; print summaries rather than large raw data.\n"
+    "- Tools may raise an exception; wrap calls in try/except to handle failures.\n"
+    "Usage examples:\n\n"
+    "Batch + conditional workflow:\n"
+    "```python\n"
+    "print(type(tools[\"get_info\"](id='A001')))  # inspect return type first, then loop\n"
+    "results = []\n"
+    "for item in ['A001', 'A002', 'A003']:\n"
+    "    info = tools[\"get_info\"](id=item)\n"
+    "    if info.get('status') == 'active': # info is a dict, confirmed above\n"
+    "        results.append(tools[\"get_details\"](id=item))\n"
+    "    else:\n"
+    "        print(f'Skipping {item}')\n"
+    "    print(f'Processed {item}')\n"
+    "print('Collected', len(results))\n"
+    "```\n\n"
+    "Error handling:\n"
+    "```python\n"
+    "ok, failed = [], []\n"
+    "for item_id in ['A001', 'A002', 'A003']:\n"
+    "    try:\n"
+    "        r = tools[\"get_info\"](id=item_id)\n"
+    "        ok.append(r)\n"
+    "    except Exception as e:\n"
+    "        failed.append((item_id, str(e)))\n"
+    "    print(f'{len(ok)} ok, {len(failed)} failed')\n"
+    "print('Failed:', failed[:3] if failed else 'none')\n"
+    "```"
+)
+
+
+def _coerce_block(text: str) -> tuple:
+    """Recover a Python value from one text block; ``(value, ok)``.
+
+    Structured payloads become native objects, plain text stays ``str``:
+
+      1. strict JSON (canonical structured channel for well-behaved servers);
+      2. a Python ``repr`` container via ``ast.literal_eval`` — only attempted
+         when the text looks like a top-level ``[``/``{``/``(`` collection, so
+         genuine prose (file contents, error strings) is never mis-parsed;
+      3. otherwise ``(text, False)`` — caller keeps it as a string.
+    """
+    try:
+        return json.loads(text), True
+    except (json.JSONDecodeError, TypeError):
+        pass
+    if text.lstrip()[:1] not in ("[", "{", "("):
+        return text, False
+    try:
+        return ast.literal_eval(text), True
+    except (ValueError, SyntaxError, MemoryError, RecursionError):
+        return text, False
+
+
+def _stringify_result(result: Any) -> Any:
+    """Recover a *native* Python value from an MCP ``CallToolResult``.
+
+    The tool's payload crossed the MCP boundary boxed into text content
+    blocks, so we always parse it back into a native ``dict``/``list``/scalar
+    and do so *deterministically* — the same tool yields the same type on
+    every call. That predictability matters: a value that is "sometimes a
+    parsed list, sometimes its raw string" makes generated code guess wrong
+    (``json.loads`` on an already-parsed list, or ``row['x']`` on an unparsed
+    string), which is exactly the failure loop native returns avoid.
+
+      1. coerce the joined text content *once* — JSON, then a Python ``repr``
+         container;
+      2. only genuinely unparseable prose (file contents, error strings) stays
+         ``str`` — itself consistent, since such a tool always returns prose.
+    """
+    try:
+        if isinstance(result, dict):
+            content = result.get("content")
+        else:
+            content = getattr(result, "content", None)
+        texts: List[str] = []
+        for item in content or ():
+            if isinstance(item, dict):
+                text = item.get("text")
+            else:
+                text = getattr(item, "text", None)
+            if text is not None:
+                texts.append(text)
+        joined = "\n".join(texts) if texts else None
+
+        if not texts:
+            if hasattr(result, "model_dump"):
+                try:
+                    return result.model_dump(mode="json")
+                except Exception:
+                    pass
+            if isinstance(result, (str, int, float, bool, list, dict)) or result is None:
+                return result
+            return str(result)
+
+        # Coerce the joined payload exactly once, so a given tool's result — and
+        # therefore its type — is deterministic across calls.
+        value, _ = _coerce_block(joined)
+        return value
+    except Exception:
+        return str(result)
+
+
+def _result_error_text(result: Any) -> Optional[str]:
+    """Return the error message when an MCP ``CallToolResult`` signals failure.
+
+    Tool failures arrive as ``isError: True`` on an *otherwise normal* result —
+    the MCP convention. ``server.call_tool`` does **not** raise for them, so
+    this check is what turns a failure into an exception inside the sandbox;
+    without it the error text flows onward disguised as data, generated code
+    subscripts the error string as if it were a row, and its ``try/except``
+    never fires.
+
+    Returns the extracted error text on failure, otherwise ``None``.
+    """
+    if isinstance(result, dict):
+        is_err = result.get("isError")
+    else:
+        is_err = getattr(result, "isError", None)
+    if is_err:
+        text = _stringify_result(result)
+        if not isinstance(text, str):
+            text = repr(text)
+        return text or "tool reported an error (isError) with no message"
+
+    return None
+
+
+def _jsonify(value: Any) -> Any:
+    """Reduce a recovered value to JSON-clean types.
+
+    Used at the MCP argument boundary: str/int/float/bool/None inside plain
+    list/dict containers — Decimal→float, datetime/date/time→ISO string,
+    tuple/set→list; anything else degrades to str(). Total function, so the
+    result always survives json.dumps.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_jsonify(v) for v in value]
+    if isinstance(value, dict):
+        return {
+            (k if isinstance(k, str) else str(k)): _jsonify(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (_datetime.datetime, _datetime.date, _datetime.time)):
+        return value.isoformat()
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value).decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _truncate_output(text: str, limit: int) -> str:
+    """Middle-truncate `text` to ~`limit` chars, keeping head and tail."""
+    if limit <= 0 or len(text) <= limit:
+        return text
+    head = int(limit * 0.7)
+    tail = limit - head
+    omitted = len(text) - head - tail
+    return (
+        f"{text[:head]}\n...[output truncated: {omitted} chars omitted; "
+        f"print concise summaries instead of large raw data]...\n{text[-tail:]}"
+    )
+
+
+# Appended whenever the worker dies. A killed worker is respawned lazily by
+# _ensure_worker() on the next call, so the model's next step is simply to
+# retry — but only if it is told, otherwise a bare crash message reads like a
+# dead end and the following NameError (state was reset) looks unexplained.
+_RESTART_NOTE = (
+    " — a fresh Python session starts automatically on your next "
+    "programmatic_tool_call, but all variables, imports and function "
+    "definitions are lost, so re-create any state you still need"
+)
+
+
+def _ptc_text_result(text: str, is_error: bool = True) -> CallToolResult:
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        isError=is_error,
+    )
+
+
+def _format_exec_result(msg: Dict[str, Any]) -> CallToolResult:
+    parts: List[str] = []
+    if msg.get("stdout"):
+        parts.append(str(msg["stdout"]))
+    if msg.get("stderr"):
+        parts.append("STDERR:\n" + str(msg["stderr"]))
+    if msg.get("error"):
+        parts.append("ERROR:\n" + str(msg["error"]))
+    text = _truncate_output("\n".join(parts) if parts else "", _MAX_OUTPUT_CHARS)
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],
+        isError=bool(msg.get("error")),
+    )
+
+
+class PTCWrapper:
+    """Aggregates underlying MCP servers behind a single ``programmatic_tool_call`` tool."""
+
+    CODE_EXECUTION_TOOL = "programmatic_tool_call"
+
+    def __init__(
+        self,
+        servers: List[MCPServer],
+        workspace: Optional[str] = None,
+        default_code_timeout: int = 60,
+    ):
+        self._servers: List[MCPServer] = list(servers)
+        self._workspace = os.path.abspath(workspace) if workspace else os.getcwd()
+        self._default_code_timeout = int(default_code_timeout)
+
+        # exposed_name -> (server, original_tool_name)
+        self._tool_index: Dict[str, Tuple[MCPServer, str]] = {}
+        # exposed_name -> ordered parameter list (for positional-arg binding)
+        self._tool_param_order: Dict[str, List[str]] = {}
+        # exposed_name -> tool description (for unknown-name suggestions)
+        self._tool_descriptions: Dict[str, str] = {}
+        self._index_built = False
+        self._index_lock = asyncio.Lock()
+
+        self._proc: Optional[asyncio.subprocess.Process] = None
+        self._proc_lock = asyncio.Lock()
+        self._tmp_dir: Optional[str] = None
+        self._script_path: Optional[str] = None
+
+    async def setup(self) -> None:
+        await self._ensure_index()
+
+    async def aclose(self) -> None:
+        await self._kill_worker()
+        if self._tmp_dir and os.path.isdir(self._tmp_dir):
+            shutil.rmtree(self._tmp_dir, ignore_errors=True)
+            self._tmp_dir = None
+
+    def code_execution_tool(self) -> MCPTool:
+        return MCPTool(
+            name=self.CODE_EXECUTION_TOOL,
+            description=_CODE_EXECUTION_DESCRIPTION,
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": (
+                            "Python code. Use tools[\"func_name\"](*args, "
+                            "**kwargs) to call env tools."
+                        ),
+                    },
+                },
+                "required": ["code"],
+            },
+        )
+
+    @property
+    def known_tools(self) -> List[str]:
+        return sorted(self._tool_index.keys())
+
+    async def _ensure_index(self) -> None:
+        if self._index_built:
+            return
+        async with self._index_lock:
+            if self._index_built:
+                return
+            for server in self._servers:
+                server_name = getattr(server, "name", "") or ""
+                try:
+                    tools = await server.list_tools()
+                except Exception as exc:
+                    logger.warning(
+                        "PTC: failed to list tools from server %r: %s",
+                        server_name, exc,
+                    )
+                    continue
+                for tool in tools:
+                    tname = getattr(tool, "name", None)
+                    if not tname:
+                        continue
+                    exposed = f"{server_name}-{tname}"
+                    self._tool_index[exposed] = (server, tname)
+                    schema = getattr(tool, "inputSchema", None) or {}
+                    if not isinstance(schema, dict):
+                        schema = {}
+                    props = schema.get("properties") or {}
+                    if not isinstance(props, dict):
+                        props = {}
+                    # JSON object key order is preserved in dict iteration.
+                    self._tool_param_order[exposed] = list(props.keys())
+                    self._tool_descriptions[exposed] = getattr(tool, "description", None) or ""
+            self._index_built = True
+            logger.info(
+                "PTC index built: %d tools across %d server(s)",
+                len(self._tool_index), len(self._servers),
+            )
+
+    async def call_programmatic(self, code: str) -> CallToolResult:
+        await self._ensure_index()
+        return await self._handle_code_execution({"code": code})
+
+    async def _handle_code_execution(self, arguments: Dict[str, Any]) -> CallToolResult:
+        code = arguments.get("code") or ""
+        timeout = self._default_code_timeout
+
+        filename = f"ptc_{uuid.uuid4().hex[:8]}.py"
+        tmp_dir = self._ensure_tmp_dir()
+        file_path = os.path.join(tmp_dir, filename)
+        try:
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(code)
+        except Exception as exc:
+            return _ptc_text_result(f"[ptc] failed to write code file: {exc}")
+
+        async with self._proc_lock:
+            try:
+                await self._ensure_worker()
+            except Exception as exc:
+                return _ptc_text_result(
+                    f"[ptc] worker failed to start: {exc}{_RESTART_NOTE}"
+                )
+
+            try:
+                await self._send({"type": "exec", "code": code, "file_path": file_path})
+            except (BrokenPipeError, ConnectionResetError, OSError) as exc:
+                await self._kill_worker()
+                return _ptc_text_result(
+                    f"[ptc] worker crashed before exec: {exc}{_RESTART_NOTE}"
+                )
+
+            deadline = time.monotonic() + timeout
+            timeout_msg = (
+                f"[ptc] execution timed out after {timeout}s{_RESTART_NOTE}"
+            )
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    await self._kill_worker()
+                    return _ptc_text_result(timeout_msg)
+                try:
+                    msg = await self._readline(remaining)
+                except asyncio.TimeoutError:
+                    await self._kill_worker()
+                    return _ptc_text_result(timeout_msg)
+                if msg is None:
+                    await self._kill_worker()
+                    return _ptc_text_result(
+                        "[ptc] the Python session crashed (the code likely "
+                        "killed the interpreter, e.g. os._exit or a segfault)"
+                        f"{_RESTART_NOTE}"
+                    )
+
+                mtype = msg.get("type")
+                if mtype == "done":
+                    return _format_exec_result(msg)
+                if mtype == "tool_call":
+                    await self._handle_tool_call(msg)
+                    continue
+                logger.warning("PTC worker sent unknown message: %s", mtype)
+
+    async def _handle_tool_call(self, msg: Dict[str, Any]) -> None:
+        req_id = msg.get("id")
+        tool_name = msg.get("tool_name") or ""
+        args = msg.get("args") or []
+        kwargs = msg.get("kwargs") or {}
+
+        # The agent sees the prefixed name ("ptc-programmatic_tool_call");
+        # accept the bare name too in case a caller strips the prefix.
+        prefixed = f"{PTCSyntheticServer.SERVER_NAME}-{self.CODE_EXECUTION_TOOL}"
+        if tool_name == self.CODE_EXECUTION_TOOL or tool_name == prefixed:
+            await self._send({
+                "type": "tool_result", "id": req_id, "ok": False,
+                "error": (
+                    f"'{self.CODE_EXECUTION_TOOL}' must be invoked as a direct "
+                    "tool call, not from inside programmatic_tool_call"
+                ),
+            })
+            return
+
+        # Self-correction for hallucinated tool names: surface valid candidates
+        # instead of letting the inner server reply with an opaque
+        # "Method <name> not found".
+        target = self._tool_index.get(tool_name)
+        if target is None:
+            await self._send({
+                "type": "tool_result", "id": req_id,
+                "ok": False, "error": self._unknown_tool_message(tool_name),
+            })
+            return
+
+        server, original_name = target
+        try:
+            bound_kwargs = self._bind_positional(tool_name, args, kwargs)
+        except Exception as exc:
+            await self._send({
+                "type": "tool_result", "id": req_id, "ok": False,
+                "error": f"argument binding failed: {exc}",
+            })
+            return
+
+        try:
+            # MCP arguments must be JSON-clean.
+            raw = await server.call_tool(original_name, _jsonify(bound_kwargs))
+            err = _result_error_text(raw)
+            if err is not None:
+                # An MCP-level failure (isError) — surface it as ok:False so the
+                # worker raises, instead of returning the error text as a value.
+                reply = {"type": "tool_result", "id": req_id, "ok": False, "error": err}
+            else:
+                value = _jsonify(_stringify_result(raw))
+                reply = {"type": "tool_result", "id": req_id, "ok": True, "value": value}
+        except Exception as exc:
+            reply = {
+                "type": "tool_result", "id": req_id,
+                "ok": False, "error": f"{type(exc).__name__}: {exc}",
+            }
+
+        try:
+            await self._send(reply)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            await self._kill_worker()
+        except (TypeError, ValueError) as exc:
+            # A value _jsonify missed. The worker is still blocked
+            # on this req_id — answer with an error rather than leaving the
+            # protocol desynced (which turns every later call into a timeout).
+            try:
+                await self._send({
+                    "type": "tool_result", "id": req_id, "ok": False,
+                    "error": f"tool result could not be serialized: {exc}",
+                })
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                await self._kill_worker()
+
+    def _bind_positional(
+        self, tool_name: str, args: List[Any], kwargs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Resolve positional args against the tool's declared parameter order."""
+        if not args:
+            return dict(kwargs)
+        order = self._tool_param_order.get(tool_name)
+        if order is None:
+            raise ValueError(
+                f"unknown tool '{tool_name}' (positional args require a known schema)"
+            )
+        out = dict(kwargs)
+        idx = 0
+        for pname in order:
+            if idx >= len(args):
+                break
+            if pname in out:
+                continue
+            out[pname] = args[idx]
+            idx += 1
+        if idx < len(args):
+            raise ValueError(
+                f"too many positional arguments for '{tool_name}': "
+                f"got {len(args)}, schema declares {len(order)} parameter(s)"
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # Self-correction for unknown tool names.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _tokenize(text: str) -> set:
+        return {t for t in re.split(r"[^a-z0-9]+", text.lower()) if t}
+
+    def _closest_tools(self, tool_name: str, n: int = 3) -> List[str]:
+        """Rank known tool names by similarity to a (probably misremembered) name.
+
+        Tool names often follow a REST-verb convention (``API-post-page`` to
+        *create* a page), so a name-only fuzzy match misleads — the model's
+        intent ("create a page") lives in the description. Score each candidate
+        on token overlap against name + description, tie-broken by raw name
+        similarity, so e.g. ``API-create-a-page`` surfaces ``API-post-page``
+        ("Notion | Create a page").
+        """
+        wanted = self._tokenize(tool_name)
+        scored = []
+        for name in self._tool_index:
+            tokens = self._tokenize(name) | self._tokenize(
+                self._tool_descriptions.get(name, "")
+            )
+            overlap = len(wanted & tokens) / len(wanted) if wanted else 0.0
+            name_ratio = difflib.SequenceMatcher(None, tool_name, name).ratio()
+            score = overlap + 0.3 * name_ratio
+            if score > 0:
+                scored.append((score, name))
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        return [name for _, name in scored[:n]]
+
+    def _unknown_tool_message(self, tool_name: str) -> str:
+        suggestions = self._closest_tools(tool_name)
+        if suggestions:
+            hint = "Did you mean: " + ", ".join(suggestions) + "?"
+        else:
+            hint = "See the available tools list for valid names."
+        return (
+            f"Unknown tool '{tool_name}'. {hint} "
+            "Use exact prefixed names, e.g. 'serverName-toolName'."
+        )
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle.
+    # ------------------------------------------------------------------
+
+    def _ensure_tmp_dir(self) -> str:
+        if self._tmp_dir and os.path.isdir(self._tmp_dir):
+            return self._tmp_dir
+        self._tmp_dir = tempfile.mkdtemp(prefix="toolathlon_ptc_")
+        self._script_path = os.path.join(self._tmp_dir, "_ptc_worker.py")
+        with open(self._script_path, "w", encoding="utf-8") as f:
+            f.write(_PERSISTENT_WORKER)
+        return self._tmp_dir
+
+    async def _ensure_worker(self) -> None:
+        if self._proc is not None and self._proc.returncode is None:
+            return
+        if self._proc is not None:
+            logger.warning(
+                "PTC worker exited (code %s) — restarting (state reset)",
+                self._proc.returncode,
+            )
+            self._proc = None
+
+        self._ensure_tmp_dir()
+        self._proc = await asyncio.create_subprocess_exec(
+            sys.executable, self._script_path,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._workspace,
+        )
+
+        init = json.dumps({"workspace": self._workspace}) + "\n"
+        self._proc.stdin.write(init.encode())
+        await self._proc.stdin.drain()
+
+        try:
+            line = await asyncio.wait_for(self._proc.stdout.readline(), timeout=15)
+            ready = json.loads(line) if line else {}
+            if ready.get("type") != "ready":
+                raise RuntimeError(f"unexpected init response: {ready}")
+        except Exception as exc:
+            await self._kill_worker()
+            raise RuntimeError(f"worker failed to start: {exc}") from exc
+
+        logger.info(
+            "PTC worker started (pid %s, cwd=%s)",
+            self._proc.pid, self._workspace,
+        )
+
+    async def _send(self, msg: Dict[str, Any]) -> None:
+        if self._proc is None or self._proc.stdin is None:
+            raise BrokenPipeError("PTC worker is not running")
+        data = (json.dumps(msg) + "\n").encode()
+        self._proc.stdin.write(data)
+        await self._proc.stdin.drain()
+
+    async def _readline(self, timeout: float) -> Optional[Dict[str, Any]]:
+        if self._proc is None or self._proc.stdout is None:
+            return None
+        line = await asyncio.wait_for(self._proc.stdout.readline(), timeout=timeout)
+        if not line:
+            return None
+        return json.loads(line)
+
+    async def _kill_worker(self) -> None:
+        proc = self._proc
+        self._proc = None
+        if proc is None:
+            return
+        try:
+            proc.kill()
+            await proc.wait()
+        except (ProcessLookupError, OSError):
+            pass
+
+
+class PTCSyntheticServer(MCPServer):
+    """Exposes a ``PTCWrapper`` as a single-tool MCP server.
+
+    The Toolathlon agent loop iterates ``MCPServerManager.connected_servers``
+    and converts each server's tools through ``my_to_function_tool``, which
+    prefixes the tool name with the server name. Plugging this synthetic
+    server in there means the model sees a regular tool named
+    ``ptc-programmatic_tool_call`` with no other code changes.
+    """
+
+    SERVER_NAME = "ptc"
+
+    def __init__(self, wrapper: PTCWrapper):
+        self._wrapper = wrapper
+        # Mirror the MCPServerStdio API so the agents framework can read it.
+        self.cache_tools_list = True
+
+    @property
+    def name(self) -> str:
+        return self.SERVER_NAME
+
+    async def connect(self):
+        # Real servers were already connected before this wrapper was built;
+        # the worker is started lazily on the first programmatic_tool_call.
+        return None
+
+    async def cleanup(self):
+        await self._wrapper.aclose()
+
+    def invalidate_tools_cache(self):
+        return None
+
+    async def list_tools(self) -> List[MCPTool]:
+        return [self._wrapper.code_execution_tool()]
+
+    async def call_tool(
+        self, tool_name: str, arguments: Optional[Dict[str, Any]]
+    ) -> CallToolResult:
+        if tool_name != PTCWrapper.CODE_EXECUTION_TOOL:
+            return _ptc_text_result(
+                f"[ptc] unknown tool '{tool_name}' — only "
+                f"'{PTCWrapper.CODE_EXECUTION_TOOL}' is exposed."
+            )
+        return await self._wrapper.call_programmatic(
+            (arguments or {}).get("code") or ""
+        )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.cleanup()
+        return False

--- a/utils/mcp/tool_servers.py
+++ b/utils/mcp/tool_servers.py
@@ -19,17 +19,28 @@ class ToolCallError(Exception):
 class MCPServerManager:
     """MCP server manager, for initializing and managing multiple MCP servers"""
 
-    def __init__(self, 
-                 agent_workspace: str, 
+    # Reserved synthetic server name used by the PTC wrapper.
+    PTC_SYNTHETIC_NAME = "ptc"
+
+    def __init__(self,
+                 agent_workspace: str,
                  config_dir: str = "configs/mcp_servers",
                  debug: bool = False,
-                 local_token_key_session: Dict = None):
+                 local_token_key_session: Dict = None,
+                 programmatic_tool_calling: bool = False,
+                 ptc_timeout_seconds: int = 60):
         """
         Initialize MCP server manager
-        
+
         Args:
             agent_workspace: Agent workspace path
             config_dir: Configuration file directory path
+            programmatic_tool_calling: When True, after `connect_servers` finishes,
+                a synthetic ``ptc`` server is appended to ``connected_servers`` that
+                exposes a single ``programmatic_tool_call`` tool. Inside that tool's
+                Python sandbox, code can call any underlying MCP tool by its
+                prefixed name (``tools["<server>-<tool>"](...)``).
+            ptc_timeout_seconds: Per-call wall-clock budget for code execution.
         """
         self.local_servers_paths = os.path.abspath("./local_servers")
         self.local_binary_paths = os.path.abspath("./local_binary")
@@ -43,7 +54,13 @@ class MCPServerManager:
         self._server_tasks: Dict[str, asyncio.Task] = {}
         # Save the event of connection completion
         self._connection_events: Dict[str, asyncio.Event] = {}
-        
+
+        # PTC state
+        self._ptc_enabled = bool(programmatic_tool_calling)
+        self._ptc_timeout = int(ptc_timeout_seconds)
+        self._ptc_wrapper = None  # type: Optional[Any]
+        self._ptc_synthetic_server = None  # type: Optional[Any]
+
         # Load servers from configuration files
         self._load_servers_from_configs(config_dir)
 
@@ -280,15 +297,79 @@ class MCPServerManager:
                     print(f"Warning: Only {connected_count} servers connected, expected {len(tasks_to_wait)}")
                     raise ValueError(f"Only {connected_count} servers connected, expected {len(tasks_to_wait)}")
 
-    async def disconnect_servers(self, server_names: Optional[List[str]] = None, 
+        # Build the PTC synthetic server *after* all real servers are connected,
+        # so its index can enumerate every tool the agent can reach.
+        if self._ptc_enabled and self._ptc_synthetic_server is None:
+            await self._setup_ptc_synthetic_server()
+
+    async def _setup_ptc_synthetic_server(self) -> None:
+        """Lazy import + build of the PTC wrapper. No-op if no servers connected."""
+        # Don't shadow real connected servers if 'ptc' was somehow used as a
+        # real server name in configs/mcp_servers — surface an error instead.
+        if self.PTC_SYNTHETIC_NAME in self.connected_servers:
+            raise ValueError(
+                f"Cannot enable programmatic_tool_calling: a real MCP server is "
+                f"already named {self.PTC_SYNTHETIC_NAME!r}. Rename it in "
+                f"configs/mcp_servers/."
+            )
+        real_servers = list(self.connected_servers.values())
+        if not real_servers:
+            if self.debug:
+                print(">>PTC requested but no real servers are connected; skipping PTC setup")
+            return
+
+        # Import lazily so loading this module does not require the PTC
+        # dependencies if the feature is off.
+        from utils.mcp.ptc_wrapper import PTCWrapper, PTCSyntheticServer
+
+        wrapper = PTCWrapper(
+            servers=real_servers,
+            workspace=self.agent_workspace,
+            default_code_timeout=self._ptc_timeout,
+        )
+        await wrapper.setup()
+        synthetic = PTCSyntheticServer(wrapper)
+
+        self._ptc_wrapper = wrapper
+        self._ptc_synthetic_server = synthetic
+        self.connected_servers[self.PTC_SYNTHETIC_NAME] = synthetic
+
+        if self.debug:
+            print(
+                f">>PTC enabled: indexed {len(wrapper.known_tools)} tools across "
+                f"{len(real_servers)} server(s) — exposed as "
+                f"'{self.PTC_SYNTHETIC_NAME}-{wrapper.CODE_EXECUTION_TOOL}'"
+            )
+
+    async def _cleanup_ptc_synthetic_server(self) -> None:
+        """Shut down the PTC worker and drop the synthetic server entry."""
+        synthetic = self._ptc_synthetic_server
+        self._ptc_synthetic_server = None
+        self._ptc_wrapper = None
+        if synthetic is None:
+            return
+        try:
+            await synthetic.cleanup()
+        except Exception as e:  # noqa: BLE001
+            if self.debug:
+                print(f">>PTC cleanup failed: {e}")
+        self.connected_servers.pop(self.PTC_SYNTHETIC_NAME, None)
+
+    async def disconnect_servers(self, server_names: Optional[List[str]] = None,
                                 max_disconnect_retries: int = 3, disconnect_retry_delay: float = 1.0):
         """Disconnect specified servers"""
+        # Tear down the PTC synthetic server first so its worker subprocess is
+        # gone before we let go of the underlying MCP servers it might still
+        # be talking to.
+        if server_names is None or self.PTC_SYNTHETIC_NAME in server_names:
+            await self._cleanup_ptc_synthetic_server()
+
         async with self._lock:
             if server_names is None:
                 servers_to_disconnect = list(self._server_tasks.keys())
             else:
                 servers_to_disconnect = [
-                    name for name in server_names 
+                    name for name in server_names
                     if name in self._server_tasks
                 ]
             
@@ -371,8 +452,13 @@ class MCPServerManager:
 
     async def ensure_all_disconnected(self, max_cleanup_retries: int = 3, cleanup_retry_delay: float = 1.0):
         """Ensure all servers are disconnected (for cleanup)"""
+        # PTC synthetic server is tracked outside _server_tasks; tear it down
+        # explicitly so disconnect_servers' lifecycle loop doesn't have to
+        # know about it.
+        await self._cleanup_ptc_synthetic_server()
+
         # Try to disconnect normally first
-        await self.disconnect_servers(max_disconnect_retries=max_cleanup_retries, 
+        await self.disconnect_servers(max_disconnect_retries=max_cleanup_retries,
                                      disconnect_retry_delay=cleanup_retry_delay)
         
         # Force cancel all remaining tasks

--- a/utils/roles/task_agent.py
+++ b/utils/roles/task_agent.py
@@ -472,7 +472,9 @@ class TaskAgent:
             agent_workspace=self.task_config.agent_workspace,
             config_dir=self.mcp_config.server_config_path,
             debug=self.debug,
-            local_token_key_session=local_token_key_session
+            local_token_key_session=local_token_key_session,
+            programmatic_tool_calling=self.agent_config.tool.programmatic_tool_calling,
+            ptc_timeout_seconds=self.agent_config.tool.ptc_timeout_seconds,
         )
         await self.mcp_manager.connect_servers(self.task_config.needed_mcp_servers)
     


### PR DESCRIPTION
## Programmatic tool calling (PTC)

Adds an opt-in mode where the agent writes Python that calls the task's MCP tools directly, instead of emitting one tool call per turn:

```python
tools["canvas-list_courses"]()
tools["arxiv-search"](query="LLM agents", max_results=5)
```
A new PTCWrapper aggregates every connected MCP server behind a single programmatic_tool_call tool and runs the code in a persistent subprocess sandbox, so variables and imports survive across calls. It ships as a synthetic MCPServer, so the existing agent plumbing picks it up unchanged.

This mainly helps on tasks that need loops, conditionals, or chaining many tool calls with intermediate processing, where per-turn tool calling burns a lot of context.

Off by default - existing runs are unaffected. Enable it with "programmatic_tool_calling": true (and optionally "ptc_timeout_seconds") in the eval config's tool section, or by setting TOOLATHLON_PROGRAMMATIC_TOOL_CALLING for containerized runs.