### PR TITLE
Add PTC-only mode, and key the PTC tool index by model-facing names

### DIFF
--- a/eval_client.py
+++ b/eval_client.py
@@ -781,6 +781,11 @@ def run(
         None,
         help="Per-job override for PTC timeout in seconds (only meaningful when PTC is enabled). Requires server v1.3+."
     ),
+    ptc_only: Optional[bool] = typer.Option(
+        None,
+        "--ptc-only/--no-ptc-only",
+        help="Per-job override for PTC-only mode (implies PTC): native tools stay listed but can only be called from inside programmatic_tool_call. Requires server v1.3+."
+    ),
 ):
     """
     Submit and run a Toolathlon evaluation task.
@@ -987,6 +992,8 @@ def run(
         typer.echo(f"  PTC: {programmatic_tool_calling}")
     if ptc_timeout is not None:
         typer.echo(f"  PTC timeout: {ptc_timeout}s")
+    if ptc_only is not None:
+        typer.echo(f"  PTC-only: {ptc_only}")
 
     # Submit task
     try:
@@ -1024,6 +1031,8 @@ def run(
                 submit_data["programmatic_tool_calling"] = programmatic_tool_calling
             if ptc_timeout is not None:
                 submit_data["ptc_timeout_seconds"] = ptc_timeout
+            if ptc_only is not None:
+                submit_data["ptc_only"] = ptc_only
 
             resp = client.post(
                 f"{server_url}/submit_evaluation",

--- a/eval_server.py
+++ b/eval_server.py
@@ -88,6 +88,7 @@ class SubmitEvaluationRequest(BaseModel):
     ws_client_version: Optional[str] = None  # WebSocket client version (required for private mode in v1.3)
     programmatic_tool_calling: Optional[bool] = None  # Per-job PTC toggle (v1.3+); None means use eval-config default
     ptc_timeout_seconds: Optional[int] = None  # Per-job PTC timeout in seconds (v1.3+)
+    ptc_only: Optional[bool] = None  # Per-job PTC-only toggle (v1.3+); implies PTC when True
 
 class SubmitEvaluationResponse(BaseModel):
     status: str
@@ -591,6 +592,9 @@ async def execute_evaluation(job_id: str, mode: str, config: Dict[str, Any]):
         if config.get('ptc_timeout_seconds') is not None:
             env["TOOLATHLON_PTC_TIMEOUT"] = str(config['ptc_timeout_seconds'])
             log(f"[Server] PTC: ptc_timeout_seconds={config['ptc_timeout_seconds']}")
+        if config.get('ptc_only') is not None:
+            env["TOOLATHLON_PTC_ONLY"] = "true" if config['ptc_only'] else "false"
+            log(f"[Server] PTC: ptc_only={config['ptc_only']}")
 
         run_process = await run_command_async(
             [
@@ -866,6 +870,7 @@ async def submit_evaluation(request: Request, data: SubmitEvaluationRequest):
         "provider": data.provider,  # Add provider (v1.1+)
         "programmatic_tool_calling": data.programmatic_tool_calling,  # v1.3+
         "ptc_timeout_seconds": data.ptc_timeout_seconds,  # v1.3+
+        "ptc_only": data.ptc_only,  # v1.3+
     }
 
     asyncio.create_task(execute_evaluation(job_id, data.mode, config))
@@ -883,6 +888,8 @@ async def submit_evaluation(request: Request, data: SubmitEvaluationRequest):
         log(f"[Server] PTC override: programmatic_tool_calling={data.programmatic_tool_calling}")
     if data.ptc_timeout_seconds is not None:
         log(f"[Server] PTC override: ptc_timeout_seconds={data.ptc_timeout_seconds}")
+    if data.ptc_only is not None:
+        log(f"[Server] PTC override: ptc_only={data.ptc_only}")
 
     # Prepare rate limit info for response
     rate_limit_info = {

--- a/main.py
+++ b/main.py
@@ -41,11 +41,17 @@ async def main():
                        help="Provider")
     parser.add_argument("--programmatic_tool_calling", action="store_true",
                        help=("Enable programmatic tool calling: a synthetic "
-                             "ptc-programmatic_tool_call tool that runs Python "
+                             "programmatic_tool_call tool that runs Python "
                              "code in a persistent sandbox and proxies MCP tool "
-                             "calls through tools[\"<server>-<tool>\"](...)."))
+                             "calls through tools[\"<tool>\"](...)."))
     parser.add_argument("--ptc_timeout", type=int, default=None,
                        help="Per-call timeout (seconds) for programmatic_tool_call. Default 60.")
+    parser.add_argument("--ptc_only", action="store_true",
+                       help=("PTC-only mode (implies --programmatic_tool_calling): the "
+                             "native MCP tools stay listed so the model can read their "
+                             "schemas, but calling them directly is rejected — they can "
+                             "only be invoked via tools[...] inside "
+                             "programmatic_tool_call."))
     args = parser.parse_args()
 
     # Set Proxy (if needed)
@@ -79,7 +85,13 @@ async def main():
             print_color(f"Invalid TOOLATHLON_PTC_TIMEOUT={env_ptc_timeout!r}, ignoring.", "yellow")
     elif args.ptc_timeout is not None:
         tool_cfg['ptc_timeout_seconds'] = args.ptc_timeout
-    
+
+    env_ptc_only = os.getenv("TOOLATHLON_PTC_ONLY")
+    if env_ptc_only is not None:
+        tool_cfg['ptc_only'] = env_ptc_only.strip().lower() in ("1", "true", "yes", "on")
+    elif args.ptc_only:
+        tool_cfg['ptc_only'] = True
+
     # Parse configurations
     mcp_config, agent_config, user_config = TaskRunner.load_configs(eval_config_dict)
     # task_config = TaskConfig.from_dict(task_config_dict, 

--- a/scripts/decoupled/host_agent_loop.py
+++ b/scripts/decoupled/host_agent_loop.py
@@ -291,10 +291,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--programmatic_tool_calling", action="store_true",
                        help=("Enable programmatic tool calling on the host side: "
                              "wraps the gateway in a PTC layer that exposes "
-                             "ptc-programmatic_tool_call. Inside the sandbox, code "
-                             "calls gateway tools via tools[\"<gw>-<tool>\"](...)."))
+                             "programmatic_tool_call. Inside the sandbox, code "
+                             "calls gateway tools via tools[\"<gw>_<tool>\"](...)."))
     parser.add_argument("--ptc_timeout", type=int, default=None,
                        help="Per-call timeout (seconds) for programmatic_tool_call. Default 60.")
+    parser.add_argument("--ptc_only", action="store_true",
+                       help=("PTC-only mode (implies --programmatic_tool_calling): the "
+                             "gateway's tools stay listed but can only be invoked via "
+                             "tools[...] inside programmatic_tool_call."))
     return parser.parse_args()
 
 
@@ -315,6 +319,12 @@ def _apply_ptc_overrides(eval_config_dict: Dict[str, Any], args: argparse.Namesp
             print(f"Invalid TOOLATHLON_PTC_TIMEOUT={env_ptc_timeout!r}, ignoring.")
     elif args.ptc_timeout is not None:
         tool_cfg["ptc_timeout_seconds"] = args.ptc_timeout
+
+    env_ptc_only = os.getenv("TOOLATHLON_PTC_ONLY")
+    if env_ptc_only is not None:
+        tool_cfg["ptc_only"] = env_ptc_only.strip().lower() in ("1", "true", "yes", "on")
+    elif args.ptc_only:
+        tool_cfg["ptc_only"] = True
 
 
 async def run_host_loop(args: argparse.Namespace) -> int:

--- a/scripts/run_single_containerized.sh
+++ b/scripts/run_single_containerized.sh
@@ -146,6 +146,10 @@ if [ ! -z "${TOOLATHLON_PTC_TIMEOUT+x}" ]; then
     EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_PTC_TIMEOUT=${TOOLATHLON_PTC_TIMEOUT}")
     echo "Detected host TOOLATHLON_PTC_TIMEOUT=${TOOLATHLON_PTC_TIMEOUT}, will pass into container"
 fi
+if [ ! -z "${TOOLATHLON_PTC_ONLY+x}" ]; then
+    EXTRA_ENV_ARGS+=("-e" "TOOLATHLON_PTC_ONLY=${TOOLATHLON_PTC_ONLY}")
+    echo "Detected host TOOLATHLON_PTC_ONLY=${TOOLATHLON_PTC_ONLY}, will pass into container"
+fi
 
 # Detect TOOLATHLON_MODEL_PARAMS_FILE - will copy file and set container path later
 HOST_MODEL_PARAMS_FILE=""

--- a/utils/data_structures/agent_config.py
+++ b/utils/data_structures/agent_config.py
@@ -12,9 +12,13 @@ class Tool:
     max_inner_turns: int = 20
     # When True, MCPServerManager appends a synthetic 'ptc' server exposing
     # `programmatic_tool_call`, which runs Python code that drives the
-    # underlying MCP tools through a `tools["<server>-<tool>"]` proxy.
+    # underlying MCP tools through a `tools["<server>_<tool>"]` proxy.
     programmatic_tool_calling: bool = False
     ptc_timeout_seconds: int = 60
+    # Native MCP tools stay listed but can only be invoked from inside
+    # `programmatic_tool_call`. Implies `programmatic_tool_calling`, applied in
+    # __post_init__ so every consumer sees it.
+    ptc_only: bool = False
 
     def __post_init__(self):
         """Validate the reasonability of tool call parameters"""
@@ -24,6 +28,8 @@ class Tool:
             raise ValueError(
                 f"ptc_timeout_seconds should be >= 1, but got {self.ptc_timeout_seconds}"
             )
+        if self.ptc_only:
+            self.programmatic_tool_calling = True
 
 @dataclass
 class AgentConfig:
@@ -90,6 +96,7 @@ class AgentConfig:
                     "max_inner_turns": self.tool.max_inner_turns,
                     "programmatic_tool_calling": self.tool.programmatic_tool_calling,
                     "ptc_timeout_seconds": self.tool.ptc_timeout_seconds,
+                    "ptc_only": self.tool.ptc_only,
                 }
             }
         }
@@ -115,6 +122,7 @@ class AgentConfig:
                 "max_inner_turns": self.tool.max_inner_turns,
                 "programmatic_tool_calling": self.tool.programmatic_tool_calling,
                 "ptc_timeout_seconds": self.tool.ptc_timeout_seconds,
+                "ptc_only": self.tool.ptc_only,
             }
         }
     
@@ -178,6 +186,7 @@ def create_agent_config(
     max_inner_turns: int = 20,
     programmatic_tool_calling: bool = False,
     ptc_timeout_seconds: int = 60,
+    ptc_only: bool = False,
 ) -> AgentConfig:
     """Convenient constructor, using flat parameters"""
     return AgentConfig(
@@ -189,5 +198,6 @@ def create_agent_config(
             max_inner_turns=max_inner_turns,
             programmatic_tool_calling=programmatic_tool_calling,
             ptc_timeout_seconds=ptc_timeout_seconds,
+            ptc_only=ptc_only,
         )
     )

--- a/utils/mcp/ptc_wrapper.py
+++ b/utils/mcp/ptc_wrapper.py
@@ -5,14 +5,16 @@ The model is given one extra tool, ``programmatic_tool_call``, that runs Python
 code in a persistent subprocess sandbox. From inside the sandbox, the code
 calls the task's underlying MCP tools through a ``tools`` proxy, e.g.::
 
-    tools["canvas-list_courses"]()
-    tools["arxiv-search"](query="LLM agents", max_results=5)
+    tools["canvas_list_courses"]()
+    tools["arxiv_search"](query="LLM agents", max_results=5)
 
 The proxy forwards tool calls back to the parent over a JSON-line protocol on
 stdin/stdout; the parent looks the name up in an aggregated index built from
 all connected ``MCPServerManager`` servers and dispatches to the right one.
-Index keys are ``f"{server.name}-{tool.name}"``, matching the prefixed names
-the model already sees through ``custom_mcp_util.my_to_function_tool``.
+Index keys are the model-facing names — ``to_model_tool_name(f"{server}-{tool}")``,
+exactly what the harness puts in the model's tool list — so a name copied off
+that list resolves on the first try. Lookups normalize, so the raw
+``f"{server}-{tool}"`` spelling works too.
 
 Design points worth knowing:
   * Tool failures raise exceptions inside the sandbox, so ``try/except``
@@ -48,6 +50,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agents.mcp import MCPServer
 from mcp.types import CallToolResult, TextContent, Tool as MCPTool
+
+# Naming helpers only — importing this applies no monkey patches.
+from utils.openai_agents_monkey_patch.tool_name_aliases import to_model_tool_name
 
 logger = logging.getLogger(__name__)
 
@@ -175,8 +180,7 @@ if __name__ == "__main__":
 '''
 
 
-# Tool names are prefixed `<server>-<tool>` (hyphens), so only bracket access
-# works — the examples below use it throughout.
+# Kept byte-identical to MCPMark's `_PROGRAMMATIC_TOOL_CALL_DESCRIPTION`.
 _CODE_EXECUTION_DESCRIPTION = (
     'Run Python that calls the tools listed above as `tools["tool_name"](*args, **kwargs)`. State (variables, imports) persists across calls. Use print() to see output.\n'
     "USE WHEN: loops, conditionals, error handling, or chaining multiple tool calls with intermediate processing.\n\n"
@@ -212,6 +216,11 @@ _CODE_EXECUTION_DESCRIPTION = (
     "print('Failed:', failed[:3] if failed else 'none')\n"
     "```"
 )
+
+
+# Backend and model-facing name alike: PTCSyntheticServer skips the `<server>_`
+# prefix (see `expose_tools_unprefixed`) and there is no hyphen to alias away.
+_PTC_TOOL_NAME = "programmatic_tool_call"
 
 
 def _coerce_block(text: str) -> tuple:
@@ -386,7 +395,7 @@ def _format_exec_result(msg: Dict[str, Any]) -> CallToolResult:
 class PTCWrapper:
     """Aggregates underlying MCP servers behind a single ``programmatic_tool_call`` tool."""
 
-    CODE_EXECUTION_TOOL = "programmatic_tool_call"
+    CODE_EXECUTION_TOOL = _PTC_TOOL_NAME
 
     def __init__(
         self,
@@ -464,7 +473,9 @@ class PTCWrapper:
                     tname = getattr(tool, "name", None)
                     if not tname:
                         continue
-                    exposed = f"{server_name}-{tname}"
+                    # Key on the name the model is shown. Duplicates need no
+                    # handling: validate_model_tool_names rejects them at setup.
+                    exposed = to_model_tool_name(f"{server_name}-{tname}")
                     self._tool_index[exposed] = (server, tname)
                     schema = getattr(tool, "inputSchema", None) or {}
                     if not isinstance(schema, dict):
@@ -480,6 +491,18 @@ class PTCWrapper:
                 "PTC index built: %d tools across %d server(s)",
                 len(self._tool_index), len(self._servers),
             )
+
+    def _resolve_tool_name(self, tool_name: str) -> Optional[str]:
+        """Canonical index key for a name the sandbox asked for, if any.
+
+        Normalizes the request the way `termination_checkers` does, so the raw
+        ``<server>-<tool>`` spelling hits the same entry. This cannot resolve
+        ambiguously: the harness rejects duplicate model-facing names.
+        """
+        if tool_name in self._tool_index:
+            return tool_name
+        canonical = to_model_tool_name(tool_name)
+        return canonical if canonical in self._tool_index else None
 
     async def call_programmatic(self, code: str) -> CallToolResult:
         await self._ensure_index()
@@ -550,10 +573,12 @@ class PTCWrapper:
         args = msg.get("args") or []
         kwargs = msg.get("kwargs") or {}
 
-        # The agent sees the prefixed name ("ptc-programmatic_tool_call");
-        # accept the bare name too in case a caller strips the prefix.
-        prefixed = f"{PTCSyntheticServer.SERVER_NAME}-{self.CODE_EXECUTION_TOOL}"
-        if tool_name == self.CODE_EXECUTION_TOOL or tool_name == prefixed:
+        # Recognize the server-prefixed spelling too, so a caller that adds the
+        # prefix back gets this explanation instead of "unknown tool".
+        prefixed = to_model_tool_name(
+            f"{PTCSyntheticServer.SERVER_NAME}-{self.CODE_EXECUTION_TOOL}"
+        )
+        if to_model_tool_name(tool_name) in (self.CODE_EXECUTION_TOOL, prefixed):
             await self._send({
                 "type": "tool_result", "id": req_id, "ok": False,
                 "error": (
@@ -566,7 +591,8 @@ class PTCWrapper:
         # Self-correction for hallucinated tool names: surface valid candidates
         # instead of letting the inner server reply with an opaque
         # "Method <name> not found".
-        target = self._tool_index.get(tool_name)
+        canonical = self._resolve_tool_name(tool_name)
+        target = self._tool_index.get(canonical) if canonical else None
         if target is None:
             await self._send({
                 "type": "tool_result", "id": req_id,
@@ -576,7 +602,7 @@ class PTCWrapper:
 
         server, original_name = target
         try:
-            bound_kwargs = self._bind_positional(tool_name, args, kwargs)
+            bound_kwargs = self._bind_positional(canonical, args, kwargs)
         except Exception as exc:
             await self._send({
                 "type": "tool_result", "id": req_id, "ok": False,
@@ -684,7 +710,7 @@ class PTCWrapper:
             hint = "See the available tools list for valid names."
         return (
             f"Unknown tool '{tool_name}'. {hint} "
-            "Use exact prefixed names, e.g. 'serverName-toolName'."
+            "Use the exact names from your tool list, e.g. 'serverName_toolName'."
         )
 
     # ------------------------------------------------------------------
@@ -768,13 +794,18 @@ class PTCSyntheticServer(MCPServer):
     """Exposes a ``PTCWrapper`` as a single-tool MCP server.
 
     The Toolathlon agent loop iterates ``MCPServerManager.connected_servers``
-    and converts each server's tools through ``my_to_function_tool``, which
-    prefixes the tool name with the server name. Plugging this synthetic
-    server in there means the model sees a regular tool named
-    ``ptc-programmatic_tool_call`` with no other code changes.
+    and converts each server's tools through ``my_to_function_tool``, so
+    plugging this synthetic server in there gets the tool in front of the model
+    with no other code changes.
+
+    It is a harness detail rather than a source of tools, so it opts out of the
+    ``<server>_`` prefix: the model sees plain ``programmatic_tool_call``.
     """
 
     SERVER_NAME = "ptc"
+
+    # Honored by custom_mcp_util.my_to_function_tool.
+    expose_tools_unprefixed = True
 
     def __init__(self, wrapper: PTCWrapper):
         self._wrapper = wrapper

--- a/utils/mcp/ptc_wrapper.py
+++ b/utils/mcp/ptc_wrapper.py
@@ -28,6 +28,11 @@ Design points worth knowing:
 
 The wrapper ships as a synthetic ``MCPServer`` (``PTCSyntheticServer``) so the
 existing OpenAI-Agents-SDK plumbing picks it up with no further changes.
+
+PTC-only mode (``ptc_only=True``) keeps every native tool listed — the model
+still reads names, descriptions and schemas — but routes each real server
+through ``PTCOnlyServerProxy``, which refuses direct calls and points back at
+the sandbox. The sandbox itself is unaffected: it holds the unwrapped servers.
 """
 
 from __future__ import annotations
@@ -218,6 +223,16 @@ _CODE_EXECUTION_DESCRIPTION = (
 )
 
 
+# PTC-only variant: new opening line, body reused so the two cannot drift.
+_CODE_EXECUTION_DESCRIPTION_ONLY = (
+    'Run Python that calls the tools listed above as `tools["tool_name"](*args, **kwargs)`. '
+    "**This is the ONLY way to invoke env tools** — they cannot be called as standalone tool "
+    "calls, so every env tool must go through this sandbox. "
+    "State (variables, imports) persists across calls. Use print() to see output.\n"
+    + _CODE_EXECUTION_DESCRIPTION.split("\n", 1)[1]
+)
+
+
 # Backend and model-facing name alike: PTCSyntheticServer skips the `<server>_`
 # prefix (see `expose_tools_unprefixed`) and there is no hyphen to alias away.
 _PTC_TOOL_NAME = "programmatic_tool_call"
@@ -402,10 +417,14 @@ class PTCWrapper:
         servers: List[MCPServer],
         workspace: Optional[str] = None,
         default_code_timeout: int = 60,
+        ptc_only: bool = False,
     ):
         self._servers: List[MCPServer] = list(servers)
         self._workspace = os.path.abspath(workspace) if workspace else os.getcwd()
         self._default_code_timeout = int(default_code_timeout)
+        # Only selects the tool description here; the rejection lives in
+        # PTCOnlyServerProxy.
+        self._ptc_only = bool(ptc_only)
 
         # exposed_name -> (server, original_tool_name)
         self._tool_index: Dict[str, Tuple[MCPServer, str]] = {}
@@ -433,7 +452,11 @@ class PTCWrapper:
     def code_execution_tool(self) -> MCPTool:
         return MCPTool(
             name=self.CODE_EXECUTION_TOOL,
-            description=_CODE_EXECUTION_DESCRIPTION,
+            description=(
+                _CODE_EXECUTION_DESCRIPTION_ONLY
+                if self._ptc_only
+                else _CODE_EXECUTION_DESCRIPTION
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -788,6 +811,54 @@ class PTCWrapper:
             await proc.wait()
         except (ProcessLookupError, OSError):
             pass
+
+
+class PTCOnlyServerProxy(MCPServer):
+    """A real MCP server with its tools listed but not directly callable.
+
+    Under ptc-only the agent gets one of these per real server: ``list_tools``
+    passes through, so the model still reads schemas, while ``call_tool``
+    refuses with a normal ``isError`` result pointing at the sandbox — not an
+    exception, so the model can act on it and retry.
+
+    ``PTCWrapper`` holds the *unwrapped* servers, so sandbox calls bypass this.
+    """
+
+    def __init__(self, inner: MCPServer):
+        self._inner = inner
+
+    @property
+    def name(self) -> str:
+        return self._inner.name
+
+    # No-ops, not delegations: MCPServerManager owns the connection and drives
+    # it through the unwrapped object. Forwarding could connect twice.
+    async def connect(self):
+        return None
+
+    async def cleanup(self):
+        return None
+
+    async def list_tools(self, *args, **kwargs) -> List[MCPTool]:
+        return await self._inner.list_tools(*args, **kwargs)
+
+    async def call_tool(
+        self, tool_name: str, arguments: Optional[Dict[str, Any]] = None
+    ) -> CallToolResult:
+        # Named as the model sees it, so the suggested line is copy-pasteable.
+        exposed = to_model_tool_name(f"{self._inner.name}-{tool_name}")
+        return _ptc_text_result(
+            f"Env tool '{exposed}' cannot be invoked directly. "
+            f"Use {_PTC_TOOL_NAME} and call it as "
+            f'tools["{exposed}"](**kwargs).'
+        )
+
+    def __getattr__(self, item):
+        # cache_tools_list, invalidate_tools_cache, ... come from the real
+        # server. Guard `_inner` so a premature lookup does not recurse.
+        if item == "_inner":
+            raise AttributeError(item)
+        return getattr(self._inner, item)
 
 
 class PTCSyntheticServer(MCPServer):

--- a/utils/mcp/tool_servers.py
+++ b/utils/mcp/tool_servers.py
@@ -28,7 +28,8 @@ class MCPServerManager:
                  debug: bool = False,
                  local_token_key_session: Dict = None,
                  programmatic_tool_calling: bool = False,
-                 ptc_timeout_seconds: int = 60):
+                 ptc_timeout_seconds: int = 60,
+                 ptc_only: bool = False):
         """
         Initialize MCP server manager
 
@@ -38,9 +39,13 @@ class MCPServerManager:
             programmatic_tool_calling: When True, after `connect_servers` finishes,
                 a synthetic ``ptc`` server is appended to ``connected_servers`` that
                 exposes a single ``programmatic_tool_call`` tool. Inside that tool's
-                Python sandbox, code can call any underlying MCP tool by its
-                prefixed name (``tools["<server>-<tool>"](...)``).
+                Python sandbox, code can call any underlying MCP tool by the same
+                name the model sees for it (``tools["<server>_<tool>"](...)``).
             ptc_timeout_seconds: Per-call wall-clock budget for code execution.
+            ptc_only: Implies `programmatic_tool_calling`. Every real server is
+                replaced in ``connected_servers`` by a proxy that still lists its
+                tools but refuses direct calls, leaving the sandbox as the only
+                way to invoke them. The sandbox keeps the unwrapped servers.
         """
         self.local_servers_paths = os.path.abspath("./local_servers")
         self.local_binary_paths = os.path.abspath("./local_binary")
@@ -56,7 +61,8 @@ class MCPServerManager:
         self._connection_events: Dict[str, asyncio.Event] = {}
 
         # PTC state
-        self._ptc_enabled = bool(programmatic_tool_calling)
+        self._ptc_only = bool(ptc_only)
+        self._ptc_enabled = bool(programmatic_tool_calling) or self._ptc_only
         self._ptc_timeout = int(ptc_timeout_seconds)
         self._ptc_wrapper = None  # type: Optional[Any]
         self._ptc_synthetic_server = None  # type: Optional[Any]
@@ -320,25 +326,39 @@ class MCPServerManager:
 
         # Import lazily so loading this module does not require the PTC
         # dependencies if the feature is off.
-        from utils.mcp.ptc_wrapper import PTCWrapper, PTCSyntheticServer
+        from utils.mcp.ptc_wrapper import (
+            PTCWrapper, PTCSyntheticServer, PTCOnlyServerProxy,
+        )
 
         wrapper = PTCWrapper(
             servers=real_servers,
             workspace=self.agent_workspace,
             default_code_timeout=self._ptc_timeout,
+            ptc_only=self._ptc_only,
         )
         await wrapper.setup()
         synthetic = PTCSyntheticServer(wrapper)
 
         self._ptc_wrapper = wrapper
         self._ptc_synthetic_server = synthetic
+
+        # After the wrapper indexed `real_servers`, so the sandbox keeps the
+        # unwrapped ones. Keys are unchanged, so name-based bookkeeping holds.
+        if self._ptc_only:
+            for name, server in self.connected_servers.items():
+                self.connected_servers[name] = PTCOnlyServerProxy(server)
+
         self.connected_servers[self.PTC_SYNTHETIC_NAME] = synthetic
 
         if self.debug:
+            mode = (
+                "PTC-only enabled (native tools listed but not directly callable)"
+                if self._ptc_only else "PTC enabled"
+            )
             print(
-                f">>PTC enabled: indexed {len(wrapper.known_tools)} tools across "
-                f"{len(real_servers)} server(s) — exposed as "
-                f"'{self.PTC_SYNTHETIC_NAME}-{wrapper.CODE_EXECUTION_TOOL}'"
+                f">>{mode}: indexed {len(wrapper.known_tools)} tools across "
+                f"{len(real_servers)} server(s) — exposed to the model as "
+                f"'{wrapper.CODE_EXECUTION_TOOL}'"
             )
 
     async def _cleanup_ptc_synthetic_server(self) -> None:

--- a/utils/openai_agents_monkey_patch/custom_mcp_util.py
+++ b/utils/openai_agents_monkey_patch/custom_mcp_util.py
@@ -8,6 +8,7 @@ from typing import Any
 from utils.general.helper import print_color
 from utils.openai_agents_monkey_patch.tool_name_aliases import (
     to_model_mcp_tool_name,
+    to_model_tool_name,
 )
 
 
@@ -139,10 +140,19 @@ def my_to_function_tool(
         except Exception as e:
             logger.info(f"Error converting MCP schema to strict mode: {e}")
 
+    # Synthetic servers injecting a harness-level tool (the PTC sandbox) opt out
+    # of the `<server>_` prefix. Real servers keep it — that is what makes their
+    # names unique across servers.
+    model_facing_name = (
+        to_model_tool_name(tool.name)
+        if getattr(server, "expose_tools_unprefixed", False)
+        else to_model_mcp_tool_name(server.name, tool.name)
+    )
+
     return FunctionTool(
         # Only the model-facing alias is normalized. The callback above keeps
         # the original server/tool objects for the real MCP call.
-        name=to_model_mcp_tool_name(server.name, tool.name),
+        name=model_facing_name,
         description=tool.description or "",
         params_json_schema=schema,
         on_invoke_tool=invoke_func,

--- a/utils/roles/task_agent.py
+++ b/utils/roles/task_agent.py
@@ -475,6 +475,7 @@ class TaskAgent:
             local_token_key_session=local_token_key_session,
             programmatic_tool_calling=self.agent_config.tool.programmatic_tool_calling,
             ptc_timeout_seconds=self.agent_config.tool.ptc_timeout_seconds,
+            ptc_only=self.agent_config.tool.ptc_only,
         )
         await self.mcp_manager.connect_servers(self.task_config.needed_mcp_servers)
     


### PR DESCRIPTION
Builds on `toolathlon-verified-ptc` (PR #72) with two changes.

## 1. Key the PTC tool index by the names the model is actually shown

The sandbox index used `f"{server}-{tool}"`, on the premise that this matched what `my_to_function_tool` puts in front of the model. It does not — that path runs every name through `to_model_tool_name`, which aliases hyphens to underscores. The model was shown `canvas_list_courses` while the index only answered to `canvas-list_courses`, so a model copying a name off its own tool list missed on the first try and had to recover through the "did you mean" suggestion, burning a turn per new tool.

The index now keys on the model-facing name, importing the harness's own helper so the two cannot drift, and lookups normalize so the raw spelling still resolves. This cannot introduce ambiguity: `validate_model_tool_names` already rejects duplicate model-facing names at setup.

## 2. PTC-only mode

Mirrors MCPMark's `--ptc-only` and verl task-sync's `--only-ptc`: the native MCP tools stay listed so the model can still read their names, descriptions and schemas, but invoking one directly is refused and it can only be reached as `tools[...]` inside `programmatic_tool_call`.

MCPMark wraps a single server and can reject inside that wrapper. Here the manager owns several servers plus the synthetic `ptc` one, so the refusal lives in a per-server proxy: `PTCOnlyServerProxy` passes `list_tools` through and answers `call_tool` with an `isError` result naming the sandbox call to use instead — a result rather than an exception, so the model can act on it and retry. The manager swaps these in *after* `PTCWrapper` has indexed the real servers, so sandbox calls still reach the unwrapped ones. Only the agent's view changes; preprocess and eval scripts build their own manager.

The tool description switches to the ONLY variant, kept byte-identical to MCPMark's by reusing the body of the existing description.

### Usage

```bash
uv run main.py --ptc_only --eval_config scripts/formal_run_v0.json --task_dir finalpool/<task> ...
TOOLATHLON_PTC_ONLY=true bash scripts/run_single_containerized.sh ...
python eval_client.py run ... --ptc-only --ptc-timeout 120
```

Config knob is `Tool.ptc_only`; it implies `programmatic_tool_calling` (normalized in `__post_init__`). `TOOLATHLON_PTC_ONLY` takes precedence over the CLI flag, as the other PTC knobs do, and is forwarded into the container.

## Verification

- Direct-call interception verified through the real dispatch path (`FunctionTool.on_invoke_tool` → `MCPUtil.invoke_mcp_tool` → `server.call_tool`): under ptc-only the tool output is the refusal and the real server is never reached, while the schema stays visible to the model.
- Both tool descriptions asserted byte-identical to MCPMark's `_PROGRAMMATIC_TOOL_CALL_DESCRIPTION` / `_..._ONLY`.
- Sandbox reaches the unwrapped servers under both name spellings; positional binding, unknown-name suggestions and the self-call guard still behave.
- `MCPServerManager` swap verified: proxies in `connected_servers`, sandbox bypasses them; plain PTC leaves servers directly callable.
- `AgentConfig` round-trips `ptc_only`, and configs that never mention it still parse.
- Existing `utils/openai_agents_monkey_patch/test_tool_adapters.py` (21 tests) passes.

## Note for remote eval runs

`SubmitEvaluationRequest` ignores unknown fields, so a server that has not picked up these commits will silently drop `ptc_only` and run plain PTC. Confirm `[Server] PTC: ptc_only=True` in the server log before trusting a ptc-only result.