### PR TITLE
Make sandboxed stop tools (claim_done) terminate the loop under PTC

### DIFF
--- a/utils/mcp/ptc_wrapper.py
+++ b/utils/mcp/ptc_wrapper.py
@@ -440,6 +440,14 @@ class PTCWrapper:
         self._tmp_dir: Optional[str] = None
         self._script_path: Optional[str] = None
 
+        # Env tools dispatched from inside the sandbox, in call order. The
+        # outer trajectory records only `programmatic_tool_call`, so anything
+        # keyed on tool-call names — most importantly the termination checker
+        # matching stop tools like claim_done — must drain this to see through
+        # the sandbox. Under ptc_only a sandboxed call is the *only* spelling
+        # of a stop-tool call that exists.
+        self._dispatched_tool_calls: List[Dict[str, Any]] = []
+
     async def setup(self) -> None:
         await self._ensure_index()
 
@@ -526,6 +534,17 @@ class PTCWrapper:
             return tool_name
         canonical = to_model_tool_name(tool_name)
         return canonical if canonical in self._tool_index else None
+
+    def drain_dispatched_tool_calls(self) -> List[Dict[str, Any]]:
+        """Return sandbox-dispatched tool calls since the last drain, oldest first.
+
+        Each entry is ``{"name": <model-facing tool name>, "arguments": <dict>}``.
+        Draining clears the buffer, so consecutive drains partition the stream;
+        the agent loop drains once per interaction round, right where it
+        extracts direct tool calls for the termination check.
+        """
+        calls, self._dispatched_tool_calls = self._dispatched_tool_calls, []
+        return calls
 
     async def call_programmatic(self, code: str) -> CallToolResult:
         await self._ensure_index()
@@ -622,6 +641,13 @@ class PTCWrapper:
                 "ok": False, "error": self._unknown_tool_message(tool_name),
             })
             return
+
+        # Record the dispatch as soon as the name resolves — like a direct
+        # call, which lands in the trajectory whether or not it succeeds.
+        self._dispatched_tool_calls.append({
+            "name": canonical,
+            "arguments": _jsonify(dict(kwargs)),
+        })
 
         server, original_name = target
         try:

--- a/utils/mcp/tool_servers.py
+++ b/utils/mcp/tool_servers.py
@@ -361,6 +361,17 @@ class MCPServerManager:
                 f"'{wrapper.CODE_EXECUTION_TOOL}'"
             )
 
+    def drain_ptc_dispatched_tool_calls(self) -> List[Dict[str, Any]]:
+        """Tool calls made from inside the PTC sandbox since the last drain.
+
+        Empty when PTC is off. The agent loop merges these into the round's
+        tool-call list so sandboxed calls count for termination checking
+        (a claim_done routed through the sandbox must still stop the run).
+        """
+        if self._ptc_wrapper is None:
+            return []
+        return self._ptc_wrapper.drain_dispatched_tool_calls()
+
     async def _cleanup_ptc_synthetic_server(self) -> None:
         """Shut down the PTC worker and drop the synthetic server entry."""
         synthetic = self._ptc_synthetic_server

--- a/utils/roles/task_agent.py
+++ b/utils/roles/task_agent.py
@@ -582,10 +582,10 @@ class TaskAgent:
                     }
                 }
                 tool_calls_in_response.append(tool_call)
-        
+
         # Update tool call statistics
         self.stats["tool_calls"] += len(tool_calls_in_response)
-        
+
         # Record simplified log
         if result.final_output:
             self.logs_to_record.append({
@@ -593,7 +593,24 @@ class TaskAgent:
                 "content": result.final_output,
                 "tool_calls_count": len(tool_calls_in_response)
             })
-        
+
+        # Tool calls made from inside the PTC sandbox never appear in
+        # result.new_items — the trajectory only shows programmatic_tool_call.
+        # Merge them in so the termination checker sees a sandboxed stop tool
+        # (under ptc_only that is the only way claim_done can be invoked).
+        # Appended after stats and logs_to_record, which keep their original
+        # semantics: model-issued direct calls only.
+        if self.mcp_manager is not None:
+            for sandbox_call in self.mcp_manager.drain_ptc_dispatched_tool_calls():
+                tool_calls_in_response.append({
+                    "id": f"ptc_sandbox_{uuid.uuid4().hex[:8]}",
+                    "type": "function",
+                    "function": {
+                        "name": sandbox_call["name"],
+                        "arguments": json.dumps(sandbox_call.get("arguments") or {}),
+                    },
+                })
+
         return tool_calls_in_response
 
     async def run_interaction_loop(self,


### PR DESCRIPTION
Under PTC(-only) the model invokes claim_done from inside the programmatic_tool_call sandbox, but the trajectory only shows the sandbox tool itself, so the termination checker never matched a stop tool and the loop ran to max turns.

PTCWrapper now records every tool dispatched from the sandbox; MCPServerManager exposes a drain, and process_agent_response merges the drained calls into recent_tool_calls for the termination check. Stats and logs_to_record keep counting model-issued direct calls only.