### PR TITLE
PTC: bound worker protocol lines so large outputs can't kill the pipe

### DIFF
--- a/utils/api_model/model_provider.py
+++ b/utils/api_model/model_provider.py
@@ -437,6 +437,38 @@ class ContextTooLongError(Exception):
         self.token_count = token_count
         self.max_tokens = max_tokens
 
+
+class MalformedToolCallError(Exception):
+    """The model (or the serving-side tool parser) emitted a tool call whose
+    arguments are not valid JSON, e.g. concatenated objects like '{}{...}'.
+
+    Raised before the response is accepted, so the retry loop resamples a
+    fresh generation instead of letting the malformed call enter the history —
+    strict OpenAI-compatible servers json.loads historical arguments on every
+    later request and would 400 the whole conversation from then on.
+    """
+
+
+def _validate_tool_calls_for_ptc(output_items) -> None:
+    """Under PTC-only runs, reject a response containing undecodable tool-call
+    arguments (raises MalformedToolCallError). No-op outside PTC-only mode so
+    other scaffolds keep their existing behavior."""
+    if os.getenv("TOOLATHLON_PTC_ONLY", "").strip().lower() not in ("1", "true", "yes", "on"):
+        return
+    for item in output_items:
+        if getattr(item, "type", None) != "function_call":
+            continue
+        arguments = getattr(item, "arguments", None)
+        if not arguments:
+            continue
+        try:
+            json.loads(arguments)
+        except (json.JSONDecodeError, TypeError):
+            raise MalformedToolCallError(
+                f"tool call '{getattr(item, 'name', '?')}' has malformed arguments "
+                f"{str(arguments)[:200]!r}; resampling the response"
+            )
+
 class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
     def __init__(self, model: str, 
                  openai_client: AsyncOpenAI, 
@@ -807,6 +839,7 @@ class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
             try:
                 model_response = await self.raw_get_response(*args, **kwargs)
                 output_items = model_response.output
+                _validate_tool_calls_for_ptc(output_items)
                 if self.debug:
                     for item in output_items:
                         if isinstance(item, ExtendedResponseOutputMessage):

--- a/utils/mcp/ptc_wrapper.py
+++ b/utils/mcp/ptc_wrapper.py
@@ -67,6 +67,12 @@ logger = logging.getLogger(__name__)
 # the context. 0 disables.
 _MAX_OUTPUT_CHARS = int(os.getenv("TOOLATHLON_PTC_MAX_OUTPUT_CHARS", "10000"))
 
+# Byte cap for one line of the worker's stdout protocol. asyncio's default
+# StreamReader limit is 64 KiB; a single oversized JSON line (huge tool-call
+# args built in sandbox code) would raise "Separator is not found, and chunk
+# exceed the limit" and permanently desync the pipe.
+_PIPE_READ_LIMIT = 2 ** 26  # 64 MiB
+
 
 # Persistent worker source. Stays alive across calls; talks JSON-line on
 # stdin/stdout. Kept as a string so we can drop it onto disk lazily.
@@ -130,8 +136,28 @@ class ToolCaller:
         return _ToolProxy(str(name))
 
 
+_max_field_chars = 0  # set from the init message; 0 disables
+
+
+def _trunc(text):
+    # Bound each protocol field *before* it crosses the pipe, so a giant
+    # print() can never produce an oversized protocol line. The parent
+    # re-truncates the joined output to its own (smaller) display limit.
+    if not text or _max_field_chars <= 0 or len(text) <= _max_field_chars:
+        return text
+    head = int(_max_field_chars * 0.7)
+    tail = _max_field_chars - head
+    omitted = len(text) - head - tail
+    return (text[:head]
+            + "\n...[output truncated: %d chars omitted; "
+              "print concise summaries instead of large raw data]...\n" % omitted
+            + text[-tail:])
+
+
 def main():
+    global _max_field_chars
     init = _read_msg()
+    _max_field_chars = int(init.get("max_field_chars") or 0)
     workspace = init.get("workspace") or os.getcwd()
     try:
         os.chdir(workspace)
@@ -175,9 +201,9 @@ def main():
             tb = traceback.format_exc()
 
         _write_msg({"type": "done",
-                    "stdout": out_buf.getvalue() or None,
-                    "stderr": err_buf.getvalue() or None,
-                    "error": tb})
+                    "stdout": _trunc(out_buf.getvalue()) or None,
+                    "stderr": _trunc(err_buf.getvalue()) or None,
+                    "error": _trunc(tb)})
 
 
 if __name__ == "__main__":
@@ -1032,6 +1058,18 @@ class PTCWrapper:
                 except asyncio.TimeoutError:
                     await self._kill_worker()
                     return _ptc_text_result(timeout_msg)
+                except ValueError as exc:
+                    # Oversized protocol line (readline's LimitOverrunError
+                    # surfaces as ValueError) or a desynced/garbled JSON line
+                    # (JSONDecodeError). The pipe cannot be trusted after
+                    # either, so restart the worker instead of failing every
+                    # subsequent call.
+                    await self._kill_worker()
+                    return _ptc_text_result(
+                        f"[ptc] worker output could not be read ({exc}); the "
+                        "output was likely too large — print concise summaries "
+                        f"instead of large raw data{_RESTART_NOTE}"
+                    )
                 if msg is None:
                     await self._kill_worker()
                     return _ptc_text_result(
@@ -1235,9 +1273,16 @@ class PTCWrapper:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self._workspace,
+            limit=_PIPE_READ_LIMIT,
         )
 
-        init = json.dumps({"workspace": self._workspace}) + "\n"
+        # Worker-side cap is deliberately looser than _MAX_OUTPUT_CHARS so the
+        # final text the model sees still carries the parent's canonical
+        # truncation marker; the worker cap only bounds the protocol line.
+        init = json.dumps({
+            "workspace": self._workspace,
+            "max_field_chars": _MAX_OUTPUT_CHARS * 2 if _MAX_OUTPUT_CHARS > 0 else 0,
+        }) + "\n"
         self._proc.stdin.write(init.encode())
         await self._proc.stdin.drain()
 


### PR DESCRIPTION
The PTC worker sends exec results as one JSON line over stdio, but the parent read it via asyncio's default 64 KiB StreamReader limit, and middle-truncation only ran after the line was fully read. Any sandbox print() (or in-code tool call args) over 64 KiB raised "Separator is not found, and chunk exceed the limit" and left the pipe desynced, so every later programmatic_tool_call failed too (observed 29 consecutive failures in one trajectory).

- raise the parent's pipe read limit to 64 MiB
- truncate stdout/stderr/traceback worker-side, before they cross the pipe, so protocol lines are bounded regardless of what the code prints
- on a protocol read error (oversized/garbled line), restart the worker and return an isError result instead of failing all subsequent calls

Also, under PTC-only runs, validate tool-call arguments when a response is received and resample on malformed ones (e.g. serving-side parser emitting concatenated '{}{...}' args), which otherwise 400-poison every later request once replayed from history. Gated on TOOLATHLON_PTC_ONLY; non-PTC runs are unaffected.