### PR TITLE
PTC: bound worker protocol lines so large outputs can't kill the pipe

### DIFF
--- a/tests/test_claim_done_terminates.py
+++ b/tests/test_claim_done_terminates.py
@@ -1,0 +1,117 @@
+"""Integration test: local-claim_done must terminate the agent run immediately.
+
+Validates the fix in utils/task_runner/hooks.py:
+- With the RunLifecycle hook, invoking local-claim_done raises TaskDoneError
+  out of Runner.run instead of letting the loop continue.
+- Without the hook (control), the Runner keeps looping after claim_done and
+  only stops on a text-only output — reproducing the production bug.
+"""
+import asyncio
+import sys
+import types
+from typing import AsyncIterator, Optional
+
+# Stub out utils.general.helper so hooks.py can be imported without the
+# container's full dependency set.
+helper = types.ModuleType("utils.general.helper")
+helper.print_color = lambda *a, **k: None
+sys.modules["utils.general.helper"] = helper
+
+sys.path.insert(0, ".")
+
+from agents import Agent, Runner, RunConfig, RunHooks
+from agents.items import ModelResponse, ResponseOutputMessage, ResponseFunctionToolCall, Usage
+from agents.models.interface import Model, ModelTracing
+from agents.tool import FunctionTool, RunContextWrapper
+
+from utils.task_runner.hooks import RunLifecycle, TaskDoneError
+from utils.openai_agents_monkey_patch.tool_name_aliases import alias_function_tools
+
+
+async def on_done_invoke(context: RunContextWrapper, params_str: str) -> str:
+    return "you have claimed the task is done!"
+
+
+CLAIM_DONE_TOOL = alias_function_tools([
+    FunctionTool(
+        name="local-claim_done",
+        description="claim the task is done",
+        params_json_schema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        on_invoke_tool=on_done_invoke,
+        strict_json_schema=False,
+    )
+])[0][0]
+
+
+class LoopModel(Model):
+    """Fake model: first turn calls claim_done, second turn (if reached)
+    emits a text-only final output — proving the loop would otherwise go on."""
+
+    def __init__(self, call_claim_done: bool = True):
+        self.calls = 0
+        self.call_claim_done = call_claim_done
+
+    async def get_response(self, system_instructions, input, model_settings,
+                           tools, output_schema, handoffs, tracing, *,
+                           previous_response_id) -> ModelResponse:
+        self.calls += 1
+        if self.call_claim_done and self.calls == 1:
+            output = [
+                ResponseFunctionToolCall(
+                    id="call_1", call_id="call_1", name="local_claim_done",
+                    arguments="{}", type="function_call",
+                )
+            ]
+        else:
+            output = [ResponseOutputMessage(
+                id="msg_1", role="assistant", status="completed", type="message",
+                content=[{"type": "output_text", "text": "all done", "annotations": []}],
+            )]
+        return ModelResponse(output=output, usage=Usage(), response_id="resp_1")
+
+    def stream_response(self, *args, **kwargs) -> AsyncIterator:
+        raise NotImplementedError
+
+
+async def main():
+    agent = Agent(name="t", instructions="you are t", model=LoopModel(), tools=[CLAIM_DONE_TOOL])
+
+    # --- Test 1: with the fixed hook, claim_done aborts the run ---
+    loop_model = agent.model
+    try:
+        await Runner.run(
+            starting_agent=agent,
+            input="do it",
+            max_turns=50,
+            hooks=RunLifecycle(debug=False),
+            run_config=RunConfig(),
+        )
+        raise AssertionError("EXPECTED TaskDoneError to be raised")
+    except TaskDoneError as e:
+        print(f"PASS: Runner aborted with TaskDoneError after {loop_model.calls} model call(s): {e}")
+    except Exception as e:  # noqa: BLE001
+        raise AssertionError(f"FAIL: unexpected exception {type(e).__name__}: {e}")
+
+    # --- Test 2: control — without the hook the loop continues past claim_done ---
+    control_model = LoopModel()
+    control_agent = Agent(name="t2", instructions="you are t", model=control_model,
+                          tools=[CLAIM_DONE_TOOL])
+    result = await Runner.run(
+        starting_agent=control_agent,
+        input="do it",
+        max_turns=50,
+        hooks=RunHooks(),  # plain hooks: no claim_done handling
+        run_config=RunConfig(),
+    )
+    print(f"PASS: control loop continued ({control_model.calls} model calls) and returned "
+          f"final output: {result.final_output!r}")
+
+    print("\nALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/utils/api_model/model_provider.py
+++ b/utils/api_model/model_provider.py
@@ -437,6 +437,38 @@ class ContextTooLongError(Exception):
         self.token_count = token_count
         self.max_tokens = max_tokens
 
+
+class MalformedToolCallError(Exception):
+    """The model (or the serving-side tool parser) emitted a tool call whose
+    arguments are not valid JSON, e.g. concatenated objects like '{}{...}'.
+
+    Raised before the response is accepted, so the retry loop resamples a
+    fresh generation instead of letting the malformed call enter the history —
+    strict OpenAI-compatible servers json.loads historical arguments on every
+    later request and would 400 the whole conversation from then on.
+    """
+
+
+def _validate_tool_calls_for_ptc(output_items) -> None:
+    """Under PTC-only runs, reject a response containing undecodable tool-call
+    arguments (raises MalformedToolCallError). No-op outside PTC-only mode so
+    other scaffolds keep their existing behavior."""
+    if os.getenv("TOOLATHLON_PTC_ONLY", "").strip().lower() not in ("1", "true", "yes", "on"):
+        return
+    for item in output_items:
+        if getattr(item, "type", None) != "function_call":
+            continue
+        arguments = getattr(item, "arguments", None)
+        if not arguments:
+            continue
+        try:
+            json.loads(arguments)
+        except (json.JSONDecodeError, TypeError):
+            raise MalformedToolCallError(
+                f"tool call '{getattr(item, 'name', '?')}' has malformed arguments "
+                f"{str(arguments)[:200]!r}; resampling the response"
+            )
+
 class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
     def __init__(self, model: str, 
                  openai_client: AsyncOpenAI, 
@@ -807,6 +839,7 @@ class OpenAIChatCompletionsModelWithRetry(OpenAIChatCompletionsModel):
             try:
                 model_response = await self.raw_get_response(*args, **kwargs)
                 output_items = model_response.output
+                _validate_tool_calls_for_ptc(output_items)
                 if self.debug:
                     for item in output_items:
                         if isinstance(item, ExtendedResponseOutputMessage):

--- a/utils/mcp/ptc_wrapper.py
+++ b/utils/mcp/ptc_wrapper.py
@@ -67,6 +67,12 @@ logger = logging.getLogger(__name__)
 # the context. 0 disables.
 _MAX_OUTPUT_CHARS = int(os.getenv("TOOLATHLON_PTC_MAX_OUTPUT_CHARS", "10000"))
 
+# Byte cap for one line of the worker's stdout protocol. asyncio's default
+# StreamReader limit is 64 KiB; a single oversized JSON line (huge tool-call
+# args built in sandbox code) would raise "Separator is not found, and chunk
+# exceed the limit" and permanently desync the pipe.
+_PIPE_READ_LIMIT = 2 ** 26  # 64 MiB
+
 
 # Persistent worker source. Stays alive across calls; talks JSON-line on
 # stdin/stdout. Kept as a string so we can drop it onto disk lazily.
@@ -130,8 +136,28 @@ class ToolCaller:
         return _ToolProxy(str(name))
 
 
+_max_field_chars = 0  # set from the init message; 0 disables
+
+
+def _trunc(text):
+    # Bound each protocol field *before* it crosses the pipe, so a giant
+    # print() can never produce an oversized protocol line. The parent
+    # re-truncates the joined output to its own (smaller) display limit.
+    if not text or _max_field_chars <= 0 or len(text) <= _max_field_chars:
+        return text
+    head = int(_max_field_chars * 0.7)
+    tail = _max_field_chars - head
+    omitted = len(text) - head - tail
+    return (text[:head]
+            + "\n...[output truncated: %d chars omitted; "
+              "print concise summaries instead of large raw data]...\n" % omitted
+            + text[-tail:])
+
+
 def main():
+    global _max_field_chars
     init = _read_msg()
+    _max_field_chars = int(init.get("max_field_chars") or 0)
     workspace = init.get("workspace") or os.getcwd()
     try:
         os.chdir(workspace)
@@ -175,9 +201,9 @@ def main():
             tb = traceback.format_exc()
 
         _write_msg({"type": "done",
-                    "stdout": out_buf.getvalue() or None,
-                    "stderr": err_buf.getvalue() or None,
-                    "error": tb})
+                    "stdout": _trunc(out_buf.getvalue()) or None,
+                    "stderr": _trunc(err_buf.getvalue()) or None,
+                    "error": _trunc(tb)})
 
 
 if __name__ == "__main__":
@@ -1032,6 +1058,18 @@ class PTCWrapper:
                 except asyncio.TimeoutError:
                     await self._kill_worker()
                     return _ptc_text_result(timeout_msg)
+                except ValueError as exc:
+                    # Oversized protocol line (readline's LimitOverrunError
+                    # surfaces as ValueError) or a desynced/garbled JSON line
+                    # (JSONDecodeError). The pipe cannot be trusted after
+                    # either, so restart the worker instead of failing every
+                    # subsequent call.
+                    await self._kill_worker()
+                    return _ptc_text_result(
+                        f"[ptc] worker output could not be read ({exc}); the "
+                        "output was likely too large — print concise summaries "
+                        f"instead of large raw data{_RESTART_NOTE}"
+                    )
                 if msg is None:
                     await self._kill_worker()
                     return _ptc_text_result(
@@ -1235,9 +1273,16 @@ class PTCWrapper:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self._workspace,
+            limit=_PIPE_READ_LIMIT,
         )
 
-        init = json.dumps({"workspace": self._workspace}) + "\n"
+        # Worker-side cap is deliberately looser than _MAX_OUTPUT_CHARS so the
+        # final text the model sees still carries the parent's canonical
+        # truncation marker; the worker cap only bounds the protocol line.
+        init = json.dumps({
+            "workspace": self._workspace,
+            "max_field_chars": _MAX_OUTPUT_CHARS * 2 if _MAX_OUTPUT_CHARS > 0 else 0,
+        }) + "\n"
         self._proc.stdin.write(init.encode())
         await self._proc.stdin.drain()
 

--- a/utils/roles/task_agent.py
+++ b/utils/roles/task_agent.py
@@ -26,6 +26,7 @@ from agents.exceptions import MaxTurnsExceeded
 
 from utils.roles.context_managed_runner import ContextManagedRunner, _ServerConversationTracker
 from utils.api_model.model_provider import ContextTooLongError
+from utils.task_runner.hooks import TaskDoneError
 
 from utils.mcp.tool_servers import MCPServerManager
 from utils.api_model.model_provider import calculate_cost, get_context_window
@@ -733,6 +734,7 @@ class TaskAgent:
                 # Agent response: context reset etc handled with inner loop
                 max_inner_steps = self.agent_config.tool.max_inner_turns if not self.single_turn_mode else self.task_config.max_steps_under_single_turn_mode
                 result = None
+                claim_done_signaled = False
                 
                 while self.cumulative_inner_steps < max_inner_steps:
                     remaining_steps = max_inner_steps - self.cumulative_inner_steps
@@ -761,6 +763,14 @@ class TaskAgent:
                     except MaxTurnsExceeded as e:
                         self._debug_print(f"[THIS IS A TAG FOR MAX TURNS EXCEEDED] Max turns exceeded: {e}")
                         self.task_status = TaskStatus.MAX_TURNS_REACHED
+                        break
+                    except TaskDoneError:
+                        # The agent invoked local-claim_done, which aborts the
+                        # Runner before it produces a RunResult. The task is
+                        # complete: mark it done and stop the interaction loop.
+                        self._debug_print("Task completed via local_claim_done")
+                        self.task_status = TaskStatus.SUCCESS
+                        claim_done_signaled = True
                         break
                     except ContextTooLongError as e:
                         self._debug_print(f"Context too long detected: {e}")
@@ -837,6 +847,11 @@ class TaskAgent:
                         )
                         continue
                 
+                # local-claim_done already terminated the run; skip response
+                # processing (there is no RunResult) and finish successfully.
+                if claim_done_signaled:
+                    break
+
                 # Ensure we got a result
                 if result is None:
                     raise RuntimeError(f"Failed to get agent response within {max_inner_steps} inner steps")

--- a/utils/task_runner/hooks.py
+++ b/utils/task_runner/hooks.py
@@ -1,6 +1,23 @@
 from typing import Any
 from agents import AgentHooks, RunHooks, RunContextWrapper, Agent, Tool, TContext
+from agents.exceptions import AgentsException
 from utils.general.helper import print_color
+
+
+class TaskDoneError(AgentsException):
+    """Raised when the agent invokes ``local-claim_done``.
+
+    The system prompt promises the model that calling ``local-claim_done``
+    immediately terminates the task.  The openai-agents Runner, however, only
+    stops on a text-only final output: it keeps executing turns while the
+    model keeps calling tools, and the termination check in
+    ``TaskAgent.run_interaction_loop`` only runs *after* the Runner returns,
+    so it never fires.  Raising from ``on_tool_start`` aborts the run loop the
+    moment the stop tool is invoked, so tasks complete as intended instead of
+    dying with "Failed to get agent response within N inner steps" (or, worse,
+    "Context too long" from the loop piling up history).
+    """
+
 
 class AgentLifecycle(AgentHooks):
     """Hook for Agent lifecycle"""
@@ -42,6 +59,12 @@ class RunLifecycle(RunHooks):
         """Hook for Tool start"""
         if self.debug:
             print_color(f'>>>>Invoking tool: {tool.name}', "cyan")
+
+        # ``local-claim_done`` is the stop tool: abort the run immediately.
+        # The tool itself only returns a string, so without this the Runner
+        # would keep looping on further tool calls until max_turns.
+        if tool.name in ("local-claim_done", "local_claim_done"):
+            raise TaskDoneError("Task completed via local-claim_done")
         
     async def on_tool_end(
         self,


### PR DESCRIPTION
The PTC worker sends exec results as one JSON line over stdio, but the parent read it via asyncio's default 64 KiB StreamReader limit, and middle-truncation only ran after the line was fully read. Any sandbox print() (or in-code tool call args) over 64 KiB raised "Separator is not found, and chunk exceed the limit" and left the pipe desynced, so every later programmatic_tool_call failed too (observed 29 consecutive failures in one trajectory).

- raise the parent's pipe read limit to 64 MiB
- truncate stdout/stderr/traceback worker-side, before they cross the pipe, so protocol lines are bounded regardless of what the code prints
- on a protocol read error (oversized/garbled line), restart the worker and return an isError result instead of failing all subsequent calls

Also, under PTC-only runs, validate tool-call arguments when a response is received and resample on malformed ones (e.g. serving-side parser emitting concatenated '{}{...}' args), which otherwise 400-poison every later request once replayed from history. Gated on TOOLATHLON_PTC_ONLY; non-PTC runs are unaffected.