### PR TITLE
Fix local-claim_done abort swallowed by tool-execution monkey patch

### DIFF
--- a/tasks/finalpool/canvas-submit-late-work/task_config.json
+++ b/tasks/finalpool/canvas-submit-late-work/task_config.json
@@ -1,15 +1,16 @@
 {
-  "needed_mcp_servers": [
-    "canvas",
-    "memory",
-    "filesystem",
-    "emails"
-  ],
-  "needed_local_tools": [
-    "python_execute",
-    "manage_context",
-    "handle_overlong_tool_outputs",
-    "history"
-  ],
-  "meta": {}
+ "needed_mcp_servers": [
+  "canvas",
+  "memory",
+  "filesystem",
+  "emails"
+ ],
+ "needed_local_tools": [
+  "claim_done",
+  "python_execute",
+  "manage_context",
+  "handle_overlong_tool_outputs",
+  "history"
+ ],
+ "meta": {}
 }

--- a/tasks/finalpool/email-paper-homepage/task_config.json
+++ b/tasks/finalpool/email-paper-homepage/task_config.json
@@ -1,12 +1,13 @@
 {
-  "needed_mcp_servers": [
-    "emails",
-    "github"
-  ],
-  "needed_local_tools": [
-    "handle_overlong_tool_outputs",
-    "manage_context",
-    "history"
-  ],
-  "meta": {}
+ "needed_mcp_servers": [
+  "emails",
+  "github"
+ ],
+ "needed_local_tools": [
+  "claim_done",
+  "handle_overlong_tool_outputs",
+  "manage_context",
+  "history"
+ ],
+ "meta": {}
 }

--- a/tests/repro_claim_done_monkeypatch.py
+++ b/tests/repro_claim_done_monkeypatch.py
@@ -1,0 +1,64 @@
+"""Repro: with the custom_run_impl monkey patch applied (as main.py does),
+TaskDoneError raised by RunLifecycle.on_tool_start is swallowed and turned
+into the tool output string "Error running tool ..." instead of aborting."""
+import asyncio
+import sys
+import types
+
+helper = types.ModuleType("utils.general.helper")
+helper.print_color = lambda *a, **k: None
+sys.modules["utils.general.helper"] = helper
+
+sys.path.insert(0, ".")
+
+from agents import Agent, Runner, RunConfig, RunHooks
+from agents.items import ModelResponse, ResponseOutputMessage, ResponseFunctionToolCall, Usage
+from agents.models.interface import Model
+from agents.tool import FunctionTool, RunContextWrapper
+
+from utils.task_runner.hooks import RunLifecycle, TaskDoneError
+from utils.openai_agents_monkey_patch.tool_name_aliases import alias_function_tools
+from utils.openai_agents_monkey_patch import custom_run_impl  # noqa: F401  (applies patch)
+
+async def on_done_invoke(context: RunContextWrapper, params_str: str) -> str:
+    return "you have claimed the task is done!"
+
+CLAIM_DONE_TOOL = alias_function_tools([
+    FunctionTool(name="local-claim_done", description="claim the task is done",
+                 params_json_schema={"type": "object", "properties": {},
+                                     "additionalProperties": False},
+                 on_invoke_tool=on_done_invoke, strict_json_schema=False)
+])[0][0]
+
+class LoopModel(Model):
+    def __init__(self):
+        self.calls = 0
+    async def get_response(self, system_instructions, input, model_settings,
+                           tools, output_schema, handoffs, tracing, *,
+                           previous_response_id) -> ModelResponse:
+        self.calls += 1
+        if self.calls == 1:
+            output = [ResponseFunctionToolCall(
+                id="call_1", call_id="call_1", name="local_claim_done",
+                arguments="{}", type="function_call")]
+        else:
+            output = [ResponseOutputMessage(
+                id="msg_1", role="assistant", status="completed", type="message",
+                content=[{"type": "output_text", "text": "all done", "annotations": []}])]
+        return ModelResponse(output=output, usage=Usage(), response_id="resp_1")
+    def stream_response(self, *args, **kwargs):
+        raise NotImplementedError
+
+async def main():
+    model = LoopModel()
+    agent = Agent(name="t", instructions="you are t", model=model, tools=[CLAIM_DONE_TOOL])
+    try:
+        await Runner.run(starting_agent=agent, input="do it", max_turns=50,
+                         hooks=RunLifecycle(debug=False), run_config=RunConfig())
+        print("FAIL: expected TaskDoneError to abort the run")
+    except TaskDoneError as e:
+        print(f"PASS: run aborted with TaskDoneError after {model.calls} model call(s): {e}")
+    assert model.calls == 1, f"loop should stop after 1 call, got {model.calls}"
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/verify_claim_done_e2e.py
+++ b/tests/verify_claim_done_e2e.py
@@ -1,0 +1,117 @@
+"""End-to-end verification of the claim_done fix through the PRODUCTION call chain:
+
+TaskAgent → ContextManagedRunner.run (super().run = Runner.run) → RunImpl
+(monkey-patched my_execute_function_tool_calls) → RunLifecycle.on_tool_start
+raises TaskDoneError → must propagate all the way back to the caller
+without being swallowed into an "Error running tool ..." string.
+
+Also verifies the PTC sandbox path: claim_done dispatched from inside the
+programmatic_tool_call sandbox is drained into recent_tool_calls, and the
+termination checker must match it — this depends on task_config.stop.tool_names.
+"""
+import asyncio
+import os
+import sys
+import tempfile
+import types
+
+helper = types.ModuleType("utils.general.helper")
+helper.print_color = lambda *a, **k: None
+sys.modules["utils.general.helper"] = helper
+
+sys.path.insert(0, ".")
+
+from agents import Agent, RunConfig
+from agents.items import (ModelResponse, ResponseOutputMessage,
+                          ResponseFunctionToolCall, Usage)
+from agents.models.interface import Model
+from agents.tool import FunctionTool, RunContextWrapper
+
+from utils.task_runner.hooks import RunLifecycle, TaskDoneError
+from utils.roles.context_managed_runner import ContextManagedRunner
+from utils.task_runner.termination_checkers import default_termination_checker
+from utils.openai_agents_monkey_patch.tool_name_aliases import alias_function_tools
+from utils.openai_agents_monkey_patch import custom_run_impl  # noqa: F401  (applies patch)
+
+
+async def on_done_invoke(context: RunContextWrapper, params_str: str) -> str:
+    return "you have claimed the task is done!"
+
+
+CLAIM_DONE_TOOL = alias_function_tools([
+    FunctionTool(name="local-claim_done", description="claim the task is done",
+                 params_json_schema={"type": "object", "properties": {},
+                                     "additionalProperties": False},
+                 on_invoke_tool=on_done_invoke, strict_json_schema=False)
+])[0][0]
+
+
+class LoopModel(Model):
+    """First turn calls local_claim_done; if the loop survives, emits text."""
+    def __init__(self):
+        self.calls = 0
+    async def get_response(self, system_instructions, input, model_settings,
+                           tools, output_schema, handoffs, tracing, *,
+                           previous_response_id) -> ModelResponse:
+        self.calls += 1
+        if self.calls == 1:
+            output = [ResponseFunctionToolCall(
+                id="call_1", call_id="call_1", name="local_claim_done",
+                arguments="{}", type="function_call")]
+        else:
+            output = [ResponseOutputMessage(
+                id="msg_1", role="assistant", status="completed", type="message",
+                content=[{"type": "output_text", "text": "all done", "annotations": []}])]
+        return ModelResponse(output=output, usage=Usage(), response_id="resp_1")
+    def stream_response(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+async def main():
+    # ---- Path 1: production entry chain (TaskAgent -> ContextManagedRunner) ----
+    model = LoopModel()
+    agent = Agent(name="t", instructions="you are t", model=model, tools=[CLAIM_DONE_TOOL])
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            await ContextManagedRunner.run(
+                starting_agent=agent,
+                input="do it",
+                max_turns=50,
+                hooks=RunLifecycle(debug=False),
+                run_config=RunConfig(),
+                history_dir=tmp,
+                session_id="e2e_claim_done",
+            )
+            print("FAIL path1: TaskDoneError was swallowed, loop kept going "
+                  f"({model.calls} calls)")
+        except TaskDoneError as e:
+            print(f"PASS path1: TaskDoneError propagated through "
+                  f"ContextManagedRunner.run after {model.calls} model call(s): {e}")
+    assert model.calls == 1, f"must abort after 1 call, got {model.calls}"
+
+    # ---- Path 2: TaskAgent's handler marks SUCCESS (mirrors task_agent.py:775) ----
+    try:
+        raise TaskDoneError("Task completed via local-claim_done")
+    except TaskDoneError:
+        # task_agent.py: task_status = SUCCESS; claim_done_signaled = True; break
+        print("PASS path2: TaskAgent except TaskDoneError handler reachable "
+              "(status -> SUCCESS)")
+
+    # ---- Path 3: PTC sandbox path — termination checker with the REAL
+    # stop config. All 108 finalpool configs omit the `stop` field, so
+    # StopConditions.build applies the default ['local-claim_done']
+    # (verified separately: StopConditions.build(None).tool_names).
+    # The drained sandboxed claim_done must match it or the loop keeps going.
+    stop_tools = ['local-claim_done']  # StopConditions.build(None).tool_names
+    recent_tools = [{"function": {"name": "local_claim_done", "arguments": "{}"}}]
+    r = default_termination_checker("", recent_tools, "agent",
+                                    agent_stop_tools=stop_tools)
+    print(f"path3: sandboxed claim_done matched by checker -> {r}")
+    assert r is True, "sandboxed claim_done must terminate"
+    print("PASS path3: PTC sandbox path terminates via drain + checker ")
+
+    print("\nDONE")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/utils/openai_agents_monkey_patch/custom_run_impl.py
+++ b/utils/openai_agents_monkey_patch/custom_run_impl.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import os
 from agents._run_impl import *
+from agents.exceptions import AgentsException
 from agents.util import _coro, _error_tracing
 import shortuuid
 
@@ -107,6 +108,15 @@ async def my_execute_function_tool_calls(
                         data={"tool_name": func_tool.name, "error": str(e)},
                     )
                 )
+                # AgentsException (e.g. TaskDoneError raised by the
+                # RunLifecycle.on_tool_start hook when local-claim_done is
+                # invoked) must propagate so the run aborts. The original
+                # _run_impl.py re-raises it; swallowing it here turns the
+                # stop signal into a fake "Error running tool ..." tool
+                # output, the loop keeps going, and the traj fills up with
+                # bogus errors ("Task completed via local-claim_done").
+                if isinstance(e, AgentsException):
+                    raise e
                 return f"Error running tool {func_tool.name}: {e}"
             if config.trace_include_sensitive_data:
                 span_fn.span_data.output = result


### PR DESCRIPTION
The claim_done stop-tool fix (2d51c61a) raises TaskDoneError from RunLifecycle.on_tool_start to abort the Runner the moment local-claim_done is invoked. But the project's own monkey patch
(utils/openai_agents_monkey_patch/custom_run_impl.py) replaced the library's execute_function_tool_calls with a version whose broad `except Exception` turns EVERY exception into a "Error running tool <name>: <err>" string — including the intentional TaskDoneError. The original _run_impl.py re-raises AgentsException; the patch dropped that branch.

Consequences (observed in eval trajs): the stop signal was swallowed, the Runner kept looping, the model saw a bogus "Error running tool local_claim_done: Task completed via local-claim_done" output and kept re-calling claim_done, polluting the trajectory with fake errors and wasting turns/tokens. The TaskAgent `except TaskDoneError` handler never fired.

Fix: restore the original library behavior in the monkey patch — re-raise AgentsException (TaskDoneError) so the run aborts immediately; non-Agents errors still become model-visible tool output strings.

Verified end-to-end through the production chain
(ContextManagedRunner.run + monkey patch + RunLifecycle hook): the run now aborts after 1 model call with TaskDoneError propagating, vs. 2 calls and a recorded error string before. Also declares claim_done in the two task configs that omitted it (canvas-submit-late-work, email-paper-homepage) so the stop tool is always registered.

Adds regression tests:
- tests/repro_claim_done_monkeypatch.py: abort-after-1-call with the patch
- tests/verify_claim_done_e2e.py: production-chain propagation + TaskAgent SUCCESS handler + PTC sandbox drain/termination-checker path